### PR TITLE
Remove second slave from Mesos collectd config

### DIFF
--- a/collectd-mesos/10-mesos-slave.conf
+++ b/collectd-mesos/10-mesos-slave.conf
@@ -29,14 +29,7 @@
     Cluster "cluster-0"
     Instance "slave-0"
     Host "%%%SLAVE_IP%%%"
-    Port %%%SLAVE_0_PORT%%%
-    Verbose false
-  </Module>
-  <Module "mesos-slave">
-    Cluster "cluster-0"
-    Instance "slave-1"
-    Host "%%%SLAVE_IP%%%"
-    Port %%%SLAVE_1_PORT%%%
+    Port %%%SLAVE_PORT%%%
     Verbose false
   </Module>
 </Plugin>


### PR DESCRIPTION
In practice, it doesn't make sense to have more than one slave running
on the same host, since the same resources would be shared among the
slaves.