### PR TITLE
Fix missing thread count in built-in Generic Java stats dashboard

### DIFF
--- a/collectd-genericjmx/20-javageneric.conf
+++ b/collectd-genericjmx/20-javageneric.conf
@@ -24,7 +24,7 @@
       Collect "memory-heap"
       Collect "memory-nonheap"
       Collect "memory_pool"
-
+      Collect "threading"
     </Connection>
   </Plugin>
 </Plugin>

--- a/collectd-java/10-jmx.conf
+++ b/collectd-java/10-jmx.conf
@@ -106,5 +106,14 @@ LoadPlugin java
                 Attribute "Usage"
             </Value>
         </MBean>
+        <MBean "threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                Table false
+                InstancePrefix "jvm.threads.count"
+                Attribute "ThreadCount"
+            </Value>
+       </MBean>
     </Plugin>
 </Plugin>


### PR DESCRIPTION


In signalfx dashboard tab, there are several built in dashboards. One of them is named Generic Java stats and appears when a node is configured with 10-jmx.conf and 20-javageneric.conf. However the Thread count chart was remaining empty.

This PR fixes this adding the JMX missing config in 10-jmx.conf and adding the collect in 20-javageneric.conf
