### PR TITLE
Changes to default plugin reporting behavior

### DIFF
--- a/collectd-docker/10-docker.conf
+++ b/collectd-docker/10-docker.conf
@@ -29,3 +29,46 @@ LoadPlugin python
     Timeout 3
   </Module>
 </Plugin>
+
+LoadPlugin match_regex
+<Chain "PostCache">
+  <Rule>
+    <Match "regex">
+      Plugin "^docker$"
+    </Match>
+    <Target "jump">
+      Chain "FilterOutDetailedDockerStats"
+    </Target>
+  </Rule>
+
+  Target "write"
+</Chain>
+<Chain "FilterOutDetailedDockerStats">
+  <Rule "CpuUsage">
+    <Match "regex">
+      Type "^cpu.usage$"
+    </Match>
+    Target "return"
+  </Rule>
+  <Rule "MemoryUsage">
+    <Match "regex">
+      Type "^memory.usage$"
+    </Match>
+    Target "return"
+  </Rule>
+  <Rule "NetworkUsage">
+    <Match "regex">
+      Type "^network.usage$"
+    </Match>
+    Target "return"
+  </Rule>
+  <Rule "BlockIO">
+    <Match "regex">
+      Type "^blkio$"
+      TypeInstance "^io_service_bytes_recursive-.*"
+    </Match>
+    Target "return"
+  </Rule>
+
+  Target "stop"
+</Chain>


### PR DESCRIPTION
Added filter info to remove detailed plugin metrics by default. Prior work in this area was lost during the migration to the integrations repo being the source of truth from a .conf file perspective.