### PR TITLE
README clarification on supported ES plugin configurations

### DIFF
--- a/collectd-elasticsearch/README.md
+++ b/collectd-elasticsearch/README.md
@@ -71,7 +71,7 @@ collectd will begin emitting metrics from Elasticsearch.
 
 ### CONFIGURATION
 
-Using the example configuration file [`20-elasticsearch.conf`](././20-elasticsearch.conf) as a guide, provide values for the configuration options listed below that make sense for your environment and allow you to connect to the Elasticsearch instance to be monitored.
+Using the example configuration file [`20-elasticsearch.conf`](././20-elasticsearch.conf) as a guide, provide values for the configuration options listed below that make sense for your environment and allow you to connect to the Elasticsearch instance to be monitored. The plugin is intended to be run on a per-node basis, so you should utilize only one "Module" element definition in the 20-elasticsearch.conf configuration file.
 
 | configuration option | definition | default value |
 | ---------------------|------------|---------------|


### PR DESCRIPTION
Added note about the ES plugin currently running on a per-node basis and
only supporting a single <Module> element definition, as there was some
confusion around this previously that led to mis-configuration of this
plugin.