### PR TITLE
Reduce header level for Version Information sections in integration R…

### DIFF
--- a/collectd-aggregation/README.md
+++ b/collectd-aggregation/README.md
@@ -8,7 +8,7 @@ Use the [aggregation](https://collectd.org/wiki/index.php/Plugin:Aggregation) to
 
 See the [cpu](https://github.com/signalfx/Integrations/collectd-cpu) plugin for information on the specific metrics.  This plugin provides aggregates, by default average and summary.
 
-### Version information
+#### Version information
 
 | Software           | Version               |
 |--------------------|-----------------------|

--- a/collectd-apache/README.md
+++ b/collectd-apache/README.md
@@ -36,7 +36,7 @@ Apache worker threads can be in one of the following states:
 | Finishing    | Finishing as part of graceful shutdown  |
 | Starting     | Starting up to serve                    |
 
-### Version information
+#### Version information
 
 | Software  | Version        |
 |-----------|----------------|

--- a/collectd-cassandra/README.md
+++ b/collectd-cassandra/README.md
@@ -29,7 +29,7 @@ Use this plugin to monitor the following types of information from Cassandra nod
 
 ### REQUIREMENTS AND DEPENDENCIES
 
-### Version information
+#### Version information
 
 | Software  | Version        |
 |-----------|----------------|

--- a/collectd-couchbase/README.md
+++ b/collectd-couchbase/README.md
@@ -22,7 +22,7 @@ collects statistics from Couchbase.
 
 ### REQUIREMENTS AND DEPENDENCIES
 
-### Version information
+#### Version information
 
 | Software  | Version        |
 |-----------|----------------|

--- a/collectd-hbase/README.md
+++ b/collectd-hbase/README.md
@@ -20,7 +20,7 @@ brief: HBase metrics for collectd
 
 ### REQUIREMENTS AND DEPENDENCIES
 
-### Version information
+#### Version information
 
 | Software  | Version        |
 |-----------|----------------|

--- a/collectd-match_regex/README.md
+++ b/collectd-match_regex/README.md
@@ -6,7 +6,7 @@ brief: Filtering Metrics using the match_regex plugin
 
 Use the [match_regex](https://collectd.org/wiki/index.php/Match:RegEx) to filter metrics.
 
-### Version information
+#### Version information
 
 | Software           | Version               |
 |--------------------|-----------------------|

--- a/collectd-mongodb/README.md
+++ b/collectd-mongodb/README.md
@@ -39,7 +39,7 @@ Documentation for MongoDB can be found here: http://docs.mongodb.org/manual/
 
 ### REQUIREMENTS AND DEPENDENCIES
 
-### Version information
+#### Version information
 
 | Software  | Version        |
 |-----------|----------------|

--- a/collectd-mysql/README.md
+++ b/collectd-mysql/README.md
@@ -29,7 +29,7 @@ This plugin connects to a MySQL instance and reports on the values returned by a
 
 ### REQUIREMENTS AND DEPENDENCIES
 
-### Version information
+#### Version information
 
 | Software  | Version        |
 |-----------|----------------|


### PR DESCRIPTION
…EADMEs

Version Information sections had a too high header level which was messing with my parsing of the markdown on the app side.