### PR TITLE
Change code block formatting

### DIFF
--- a/appdynamics/README.md
+++ b/appdynamics/README.md
@@ -36,6 +36,7 @@ maven install
 cd appd-report-standalone
 maven exec:java
 ```
+
 ### CONFIGURATION
 
 #### Required Environment Variables

--- a/collectd-activemq/README.md
+++ b/collectd-activemq/README.md
@@ -30,11 +30,11 @@ Use this plugin to monitor the following types of information from ActiveMQ:
 ##### Built-in dashboards
 
 - **ActiveMQ Hosts**: Overview of all data from ActiveMQ hosts.
-  
+
   [<img src='./img/dashboard_activemq_hosts.png' width=200px>](./img/dashboard_activemq_hosts.png)
 
 - **ActiveMQ Host**: Focus on a single ActiveMQ host.
-  
+
   [<img src='./img/dashboard_activemq_host.png' width=200px>](./img/dashboard_activemq_host.png)
 
 - **ActiveMQ Queue**: Focus on a single ActiveMQ queue.
@@ -42,7 +42,7 @@ Use this plugin to monitor the following types of information from ActiveMQ:
   [<img src='./img/dashboard_activemq_queue.png' width=200px>](./img/dashboard_activemq_queue.png)
 
 - **ActiveMQ Topic**: Focus on a single ActiveMQ topic.
-  
+
   [<img src='./img/dashboard_activemq_topic.png' width=200px>](./img/dashboard_activemq_topic.png)
 
 - **ActiveMQ Message Age**: (if enabled) Shows the average age of messages in ActiveMQ queues.
@@ -67,9 +67,7 @@ Use the [generic-jmx](https://collectd.org/wiki/index.php/Plugin:GenericJMX) col
 
  Run the following command to install the Java plugin for collectd:
 
- ```
- yum install collectd-java
- ```
+        yum install collectd-java
 
  #### Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
@@ -84,10 +82,8 @@ Use the [generic-jmx](https://collectd.org/wiki/index.php/Plugin:GenericJMX) col
 
 1. Add the following lines to /etc/collectd.conf, replacing the example paths with the locations of the configuration files you downloaded in step 2:
 
- ```
- include '/path/to/10-jmx.conf'
- include '/path/to/20-activemq.conf'
- ```
+        include '/path/to/10-jmx.conf'
+        include '/path/to/20-activemq.conf'
 
 1. Restart collectd.
 

--- a/collectd-apache/README.md
+++ b/collectd-apache/README.md
@@ -24,11 +24,11 @@ The Apache plugin for collectd monitors Apache Webserver using the information p
 ##### Built-in dashboards
 
 - **Apache Webservers**: Overview of data from all Apache webserver instances.
-  
+
   [<img src='./img/dashboard_apache_webservers.png' width=200px>](./img/dashboard_apache_webservers.png)
 
 - **Apache Webserver**: Focus on a single Apache webserver instance.
-  
+
   [<img src='./img/dashboard_apache_webserver.png' width=200px>](./img/dashboard_apache_webserver.png)
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -48,12 +48,10 @@ This plugin collects metrics from the module `mod_status`.
 
 1. Add the following configuration to your Apache server:
 
- ```
- ExtendedStatus on
- <Location /mod_status>
-   SetHandler server-status
- </Location>
- ```
+        ExtendedStatus on
+        <Location /mod_status>
+          SetHandler server-status
+        </Location>
 
 1. Restart apache.
 
@@ -67,9 +65,7 @@ This plugin collects metrics from the module `mod_status`.
 
  Run the following command to install this plugin:
 
- ```
- yum install collectd-apache
- ```
+        yum install collectd-apache
 
 1. Download SignalFx's [sample configuration file](https://github.com/signalfx/integrations/blob/master/collectd-apache/10-apache.conf) for this plugin.
 
@@ -79,9 +75,7 @@ This plugin collects metrics from the module `mod_status`.
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 2:
 
- ```
- include '/path/to/10-apache.conf'
- ```
+        include '/path/to/10-apache.conf'
 
 1. Restart collectd.
 
@@ -92,12 +86,12 @@ This plugin collects metrics from the module `mod_status`.
 #### System configuration:
 
 Add the following to your apache config:
- ```
- ExtendedStatus on
+```
+ExtendedStatus on
   <Location /mod_status>
     SetHandler server-status
   </Location>
- ```
+```
 
 #### Config file modifications:
 

--- a/collectd-cassandra/README.md
+++ b/collectd-cassandra/README.md
@@ -32,11 +32,11 @@ Use this integration to monitor the following types of information from Cassandr
 ##### Built-in dashboards
 
 - **Cassandra Nodes**: Overview of data from all Cassandra nodes.
-  
+
   [<img src='./img/dashboard_cassandra_nodes.png' width=200px>](./img/dashboard_cassandra_nodes.png)
 
 - **Cassandra Node**: Focus on a single Cassandra node.
-  
+
   [<img src='./img/dashboard_cassandra_node.png' width=200px>](./img/dashboard_cassandra_node.png)
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -58,9 +58,8 @@ Use this integration to monitor the following types of information from Cassandr
 
  Run the following command to install the Java plugin for collectd:
 
- ```
- yum install collectd-java
- ```
+        yum install collectd-java
+
  Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://github.com/signalfx/integrations/tree/master/collectd).
@@ -74,10 +73,10 @@ Use this integration to monitor the following types of information from Cassandr
 1. Modify [`cassandra.conf`](https://github.com/signalfx/integrations/blob/master/collectd-cassandra/20-cassandra.conf) to provide values that make sense for your environment, as described in the header.
 
  Add the following lines to /etc/collectd.conf, replacing the example paths with the locations of the configuration files you downloaded in step 2:
- ```
- include '/path/to/10-jmx.conf'
- include '/path/to/20-cassandra.conf'
- ```
+
+        include '/path/to/10-jmx.conf'
+        include '/path/to/20-cassandra.conf'
+
 1. Restart collectd.
 
 Metrics from Cassandra will begin streaming into SignalFx, and new built-in dashboards will be created for you. Check the status of your new integration on the Integrations page.

--- a/collectd-couchbase/README.md
+++ b/collectd-couchbase/README.md
@@ -25,11 +25,11 @@ collects statistics from Couchbase.
 ##### Built-in dashboards
 
 - **Couchbase Nodes**: Overview of all data from Couchbase nodes.
-  
+
   [<img src='./img/dashboard_couchbase_nodes.png' width=200px>](./img/dashboard_couchbase_nodes.png)
 
 - **Couchbase Node**: Focus on a single Couchbase node.
-  
+
   [<img src='./img/dashboard_couchbase_node.png' width=200px>](./img/dashboard_couchbase_node.png)
 
 - **Couchbase Clusters**: Overview of data from all Couchbase clusters reporting.
@@ -37,7 +37,7 @@ collects statistics from Couchbase.
   [<img src='./img/dashboard_couchbase_clusters.png' width=200px>](./img/dashboard_couchbase_clusters.png)
 
 - **Couchbase Buckets**: Performance and activity of Couchbase buckets.
-  
+
   [<img src='./img/dashboard_couchbase_buckets.png' width=200px>](./img/dashboard_couchbase_buckets.png)
 
 - **Couchbase Bucket**: Focus on a single Couchbase bucket.
@@ -62,9 +62,8 @@ collects statistics from Couchbase.
   **RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09**
 
   Run the following command to install the Python plugin for collectd:
-  ```
-   yum install collectd-python
-  ```
+
+        yum install collectd-python
 
   **Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8**:
 
@@ -78,9 +77,7 @@ collects statistics from Couchbase.
 
 5. Add the following line to `/etc/collectd.conf`, replacing the example path with the location of the configuration file:
 
-  ```
-  Include "/path/to/10-couchbase.conf"
-  ```
+        Include "/path/to/10-couchbase.conf"
 
 6. Restart collectd.
 

--- a/collectd-docker/README.md
+++ b/collectd-docker/README.md
@@ -26,11 +26,11 @@ The [`docker-collectd`](https://github.com/signalfx/docker-collectd) plugin coll
 ##### Built-in dashboards
 
 - **Docker Hosts**: Overview of all data from Docker hosts.
-  
+
   [<img src='./img/dashboard_docker_hosts.png' width=200px>](./img/dashboard_docker_hosts.png)
 
 - **Docker Host**: Focus on a single Docker host.
-  
+
   [<img src='./img/dashboard_docker_host.png' width=200px>](./img/dashboard_docker_host.png)
 
 - **Docker Container**: Focus further on a single running Docker container.
@@ -54,9 +54,9 @@ The [`docker-collectd`](https://github.com/signalfx/docker-collectd) plugin coll
  ##### RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09
 
  Run the following command to install the Python plugin for collectd:
- ```
- yum install collectd-python
- ```
+
+         yum install collectd-python
+
  ##### Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://github.com/signalfx/integrations/tree/master/collectd).
@@ -66,15 +66,15 @@ The [`docker-collectd`](https://github.com/signalfx/docker-collectd) plugin coll
  https://github.com/signalfx/docker-collectd-plugin
 
 1. Run the following command to install the module’s dependencies using pip, replacing the example path with the location of the module you downloaded in step 2:
- ```
- pip install -r /path/to/docker-collectd-plugin/requirements.txt
- ```
- 
+
+         pip install -r /path/to/docker-collectd-plugin/requirements.txt
+
+
  *Note*: Amazon Linux users must install a version of pip that will correctly install this module's dependencies. If you're installing this plugin on an Amazon Linux system, run the following commands instead:
- ```
- yum install python26-pip
- pip-2.6 install -r /path/to/docker-collectd-plugin/requirements.txt
- ```
+
+         yum install python26-pip
+         pip-2.6 install -r /path/to/docker-collectd-plugin/requirements.txt
+
 1. Download SignalFx’s [sample configuration file](https://github.com/signalfx/integrations/blob/master/collectd-docker/10-docker.conf).
 
 1. Modify the configuration file as follows:
@@ -84,9 +84,9 @@ The [`docker-collectd`](https://github.com/signalfx/docker-collectd) plugin coll
  1. Provide values that make sense for your environment, as described [below](#configuration).
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 4:
- ```
- include '/path/to/10-docker.conf'
- ```
+
+         include '/path/to/10-docker.conf'
+
 1. Restart collectd.
 
 collectd will begin emitting metrics from Docker.

--- a/collectd-elasticsearch/README.md
+++ b/collectd-elasticsearch/README.md
@@ -31,11 +31,11 @@ Original Elasticsearch Documentation https://www.elastic.co/guide/en/elasticsear
 ##### Built-in dashboards
 
 - **Elasticsearch**: Overview of all data from Elasticsearch hosts.
-  
+
   [<img src='./img/dashboard_elasticsearch.png' width=200px>](./img/dashboard_elasticsearch.png)
 
 - **Elasticsearch Cluster**: Focus on a single Elasticsearch cluster.
-  
+
   [<img src='./img/dashboard_elasticsearch_cluster.png' width=200px>](./img/dashboard_elasticsearch_cluster.png)
 
 - **Elasticsearch Node**: Focus further on a single Elasticsearch node.
@@ -66,9 +66,9 @@ Original Elasticsearch Documentation https://www.elastic.co/guide/en/elasticsear
  ##### RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09
 
  Run the following command to install the Python plugin for collectd:
- ```
- yum install collectd-python
- ```
+
+         yum install collectd-python
+
  ##### Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://support.signalfx.com/hc/en-us/articles/208080123).
@@ -77,7 +77,7 @@ Original Elasticsearch Documentation https://www.elastic.co/guide/en/elasticsear
 
  https://github.com/signalfx/collectd-elasticsearch
 
-1. Download SignalFx’s [sample configuration file](https://github.com/signalfx/integrations/blob/master/collectd-elasticsearch/20-elasticsearch.conf). 
+1. Download SignalFx’s [sample configuration file](https://github.com/signalfx/integrations/blob/master/collectd-elasticsearch/20-elasticsearch.conf).
 
 1. Modify the configuration file as follows:
 
@@ -86,9 +86,9 @@ Original Elasticsearch Documentation https://www.elastic.co/guide/en/elasticsear
  1. Provide values that make sense for your environment, as described [below](#configuration).
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 4:
- ```
- include '/path/to/20-elasticsearch.conf'
- ```
+
+         include '/path/to/20-elasticsearch.conf'
+
 1. Restart collectd.
 
 collectd will begin emitting metrics from Elasticsearch.
@@ -127,7 +127,7 @@ The following additional threadpools can be added the variable: AdditionalThread
 #### Note: Using this plugin from a container deployment
 
  If you are running the Elasticsearch plugin via a collectd deployment within a container, please configure the Host and Port values inside of the 20-elasticsearch.conf file that correspond to the desired Elasticsearch instance.
- 
+
  ex:
 ```
    <Module "elasticsearch_collectd">
@@ -140,11 +140,11 @@ Currently only Basic Authentication is supported for the plugin.
 
 #### Note: Collecting index statistics
 
-By default, the configuration parameter Indexes is set to `"_all"`. This means that when EnableIndexStats is set to `true`, the plugin will collect statistics about all indexes. To collect statistics from only one index, set the configuration parameter Indexes to the name of that index: for example, `["index1"]`. To collect statistics from multiple indexes (but not all), include them as a comma-separated list: for example, `["index1", "index2"]`. 
- 
+By default, the configuration parameter Indexes is set to `"_all"`. This means that when EnableIndexStats is set to `true`, the plugin will collect statistics about all indexes. To collect statistics from only one index, set the configuration parameter Indexes to the name of that index: for example, `["index1"]`. To collect statistics from multiple indexes (but not all), include them as a comma-separated list: for example, `["index1", "index2"]`.
+
 SignalFx recommends enabling index statistics collection only on master-eligible Elasticsearch nodes.
 
-The call to collect index statistics can be CPU-intensive. For this reason SignalFx recommends using the `Interval` configuration parameter to decrease the reporting interval for nodes that report index statistics. 
+The call to collect index statistics can be CPU-intensive. For this reason SignalFx recommends using the `Interval` configuration parameter to decrease the reporting interval for nodes that report index statistics.
 
 ### USAGE
 

--- a/collectd-genericjmx/README.md
+++ b/collectd-genericjmx/README.md
@@ -41,9 +41,9 @@ From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:GenericJMX):
 
  Run the following command to install the Java plugin for collectd:
 
- ```
- yum install collectd-java
- ```
+
+         yum install collectd-java
+
  Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://support.signalfx.com/hc/en-us/articles/208080123).
@@ -53,9 +53,9 @@ From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:GenericJMX):
 1. Modify the configuration file providing values that make sense for your environment, as described [below](#configuration).
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 3:
- ```
- include '/path/to/10-jmx.conf'
- ```
+
+         include '/path/to/10-jmx.conf'
+
 1. Restart collectd.
 
 collectd will be ready to be configured for your Java-based application.

--- a/collectd-haproxy/README.md
+++ b/collectd-haproxy/README.md
@@ -39,17 +39,14 @@ Follow these steps to install and configure this plugin:
 
   Run the following command to install this plugin:
 
-  ```
-  yum install collectd-haproxy
-  ```
+         yum install collectd-haproxy
+
 
 1. Download SignalFx's [sample configuration file](./10-haproxy.conf) for this plugin.
 1. Modify the sample configuration file as described in [Configuration](#configuration), below.
 1. Add the following line to `/etc/collectd.conf`, replacing the example path with the location of the configuration file:
 
-  ```
-  include '/path/to/10-haproxy.conf'
-  ```
+         include '/path/to/10-haproxy.conf'
 
 1. Restart collectd.
 

--- a/collectd-hbase/README.md
+++ b/collectd-hbase/README.md
@@ -37,9 +37,8 @@ brief: HBase metrics for collectd
 
  Run the following command to install the Java plugin for collectd:
 
- ```
- yum install collectd-java
- ```
+         yum install collectd-java
+
  Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://github.com/signalfx/integrations/tree/master/collectd).
@@ -53,10 +52,10 @@ brief: HBase metrics for collectd
 1. Modify [`hbase.conf`](https://github.com/signalfx/integrations/blob/master/collectd-hbase/20-hbase.conf) to provide values that make sense for your environment, as described in the header.
 
  Add the following lines to /etc/collectd.conf, replacing the example paths with the locations of the configuration files you downloaded in step 2:
- ```
- include '/path/to/10-jmx.conf'
- include '/path/to/20-hbase.conf'
- ```
+
+         include '/path/to/10-jmx.conf'
+         include '/path/to/20-hbase.conf'
+
 1. Restart collectd.
 
 Metrics from HBase will begin streaming into SignalFx.

--- a/collectd-kafka/README.md
+++ b/collectd-kafka/README.md
@@ -24,11 +24,11 @@ This is the SignalFx Kafka plugin. It will send data about Kafka to SignalFx, en
 ##### Built-in dashboards
 
 - **Kafka**: Overview of data from all Kafka brokers.
-  
+
   [<img src='./img/dashboard_kafka.png' width=200px>](./img/dashboard_kafka.png)
 
 - **Kafka Broker**: Focus on a single Kafka broker.
-  
+
   [<img src='./img/dashboard_kafka_broker.png' width=200px>](./img/dashboard_kafka_broker.png)
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -47,9 +47,9 @@ This is the SignalFx Kafka plugin. It will send data about Kafka to SignalFx, en
 
  Run the following command to install the Java plugin for collectd:
 
- ```
- yum install collectd-java
- ```
+
+         yum install collectd-java
+
  Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://github.com/signalfx/integrations/tree/master/collectd).
@@ -65,15 +65,14 @@ This is the SignalFx Kafka plugin. It will send data about Kafka to SignalFx, en
 1. Modify the configuration file providing values that make sense for your environment, as described [below](#configuration).
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 3:
- ```
- include '/path/to/10-jmx.conf'
-  include '/path/to/20-kafka.conf'
- ```
-or
- ```
- include '/path/to/10-jmx.conf'
-  include '/path/to/20-kafka_82.conf'
- ```
+
+        include '/path/to/10-jmx.conf'
+        include '/path/to/20-kafka.conf'
+
+ or
+
+        include '/path/to/10-jmx.conf'
+        include '/path/to/20-kafka_82.conf'
 
 1. Restart collectd.
 

--- a/collectd-memcached/README.md
+++ b/collectd-memcached/README.md
@@ -33,11 +33,11 @@ Original Memcached Documentation https://code.google.com/p/memcached/wiki/NewSta
 ##### Built-in dashboards
 
 - **Memcached (a)**: Overview of data from all Memcached hosts.
-  
+
   [<img src='./img/dashboard_memcached_a.png' width=200px>](./img/dashboard_memcached_a.png)
 
 - **Memcached**: Focus on a single Memcached host.
-  
+
   [<img src='./img/dashboard_memcached.png' width=200px>](./img/dashboard_memcached.png)
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -60,17 +60,17 @@ Original Memcached Documentation https://code.google.com/p/memcached/wiki/NewSta
  ##### RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09
 
  Run the following command to install this plugin:
- ```
- yum install collectd-memcached
- ```
+
+         yum install collectd-memcached
+
 1. Download SignalFx's [sample memcached configuration file](https://github.com/signalfx/integrations/blob/master/collectd-memcached/10-memcached.conf)
 
  Modify the sample configuration file to provide values that make sense for your environment, as described in the header.
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 2:
- ```
- include '/path/to/10-memcached.conf'
- ```
+
+         include '/path/to/10-memcached.conf'
+
 1. Restart collectd.
 
 Metrics from memcached will begin streaming into SignalFx, and new built-in dashboards will be created for you. Check the status of your new integration on the Integrations page.

--- a/collectd-mesos/README.md
+++ b/collectd-mesos/README.md
@@ -19,25 +19,25 @@ Use the Mesos plugin for collectd to monitor the following information about Mes
   - Cluster status: number of activated slaves, schedulers and tasks
   - CPU, disk and memory usage for Mesos
   - Tasks finished, lost, and failed
-  
+
 #### FEATURES
 
 ##### Built-in dashboards
 
 - **Mesos Clusters**: Overview of data from all Mesos clusters.
-  
+
   [<img src='./img/dashboard_mesos_clusters.png' width=200px>](./img/dashboard_mesos_clusters.png)
 
 - **Mesos Cluster**: Focus on a single Mesos cluster.
-  
+
   [<img src='./img/dashboard_mesos_cluster.png' width=200px>](./img/dashboard_mesos_cluster.png)
 
 - **Mesos Master**: Focus further on a single Mesos master.
-  
+
   [<img src='./img/dashboard_mesos_master.png' width=200px>](./img/dashboard_mesos_master.png)
 
 - **Mesos Slave**: Focus further on a single Mesos slave.
-  
+
   [<img src='./img/dashboard_mesos_slave.png' width=200px>](./img/dashboard_mesos_slave.png)
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -59,9 +59,7 @@ Follow these steps to install this plugin:
 
  Run the following commands to install the Python plugin for collectd:
 
- ```
- yum install collectd-python
- ```
+         yum install collectd-python
 
  **Ubuntu 12.04, 14.04, 15.04 and Debian 7 & 8:**
 
@@ -72,9 +70,8 @@ Follow these steps to install this plugin:
 3. Modify the appropriate sample configuration file to contain values that make sense for your environment, as described [below](#configuration).
 4. Add the following line to collectd.conf, replacing the path with the path to the sample configuration file you downloaded in step 2:
 
-  ```
-  include '/path/to/10-mesos-[slave/master].conf'
-  ```
+         include '/path/to/10-mesos-[slave/master].conf'
+
 5. Restart collectd.
 
 ### CONFIGURATION

--- a/collectd-mongodb/README.md
+++ b/collectd-mongodb/README.md
@@ -42,13 +42,13 @@ Documentation for MongoDB can be found here: http://docs.mongodb.org/manual/
 ##### Built-in dashboards
 
 - **MongoDB Hosts**: Overview of data from all MongoDB hosts.
-  
+
   [<img src='./img/dashboard_mongodb_hosts.png' width=200px>](./img/dashboard_mongodb_hosts.png)
 
 - **MongoDB Host**: Focus on a single MongoDB host.
-  
+
   [<img src='./img/dashboard_mongodb_host.png' width=200px>](./img/dashboard_mongodb_host.png)
-  
+
 - **MongoDB Cluster**: Overview of a MongoDB cluster.
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -70,22 +70,19 @@ Documentation for MongoDB can be found here: http://docs.mongodb.org/manual/
 
  Run the following commands to install the Python plugin for collectd, `pip`, and `pymongo`:
 
- ```
- yum install -y epel-release
- yum install -y python-pip
- yum install -y collectd-python
- pip install pymongo==3.0.3
- ```
+        yum install -y epel-release
+        yum install -y python-pip
+        yum install -y collectd-python
+        pip install pymongo==3.0.3
 
  **Ubuntu 12.04, 14.04, 15.04 and Debian 7 & 8:**
 
  This plugin is included with [SignalFx's collectd package](https://github.com/signalfx/integrations/tree/master/collectd).
  Run the following commands to install `pip` and `pymongo`:
 
- ```
- apt-get install -y python-pip python-dev build-essential
- pip install pymongo==3.0.3
- ```
+        apt-get install -y python-pip python-dev build-essential
+        pip install pymongo==3.0.3
+
 1. Download the [Python module for MongoDB](https://github.com/signalfx/collectd-mongodb).  
 
 1. Download SignalFx's [sample configuration file ](././10-mongodb.conf) for this plugin.
@@ -94,9 +91,7 @@ Documentation for MongoDB can be found here: http://docs.mongodb.org/manual/
 
 1. Add the following line to `/etc/collectd.conf`, replacing the example path with the location of the configuration file:
 
- ```
- include '/path/to/10-mongodb.conf'
- ```
+        include '/path/to/10-mongodb.conf'
 
 1. Restart collectd.
 

--- a/collectd-mysql/README.md
+++ b/collectd-mysql/README.md
@@ -26,17 +26,17 @@ This plugin connects to a MySQL instance and reports on the values returned by a
   - State of the query cache
   - Status of MySQL threads
   - Network traffic
-  
+
 #### FEATURES
 
 ##### Built-in dashboards
 
 - **MySQL Nodes**: Overview of data from all MySQL nodes.
-  
+
   [<img src='./img/dashboard_mysql_nodes.png' width=200px>](./img/dashboard_mysql_nodes.png)
 
 - **MySQL Node**: Focus on a single MySQL node.
-  
+
   [<img src='./img/dashboard_mysql_node.png' width=200px>](./img/dashboard_mysql_node.png)  
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -62,17 +62,13 @@ Follow these steps to install and configure this plugin:
 
   Run the following command to install this plugin:
 
-  ```
-  yum install collectd-mysql
-  ```
+          yum install collectd-mysql
 
 1. Download SignalFx's [sample configuration file](./10-mysql.conf) for this plugin.
 1. Modify the sample configuration file as described in [Configuration](#configuration), below.
 1. Add the following line to `/etc/collectd.conf`, replacing the example path with the location of the configuration file:
 
-  ```
-  include '/path/to/10-mysql.conf'
-  ```
+          include '/path/to/10-mysql.conf'
 
 1. Restart collectd.
 

--- a/collectd-nginx/README.md
+++ b/collectd-nginx/README.md
@@ -23,11 +23,11 @@ Use the NGINX plugin for collectd to send data about NGINX to SignalFx, enabling
 ##### Built-in dashboards
 
 - **NGINX Servers**: Overview of data from all NGINX servers.
-  
+
   [<img src='./img/dashboard_nginx_servers.png' width=200px>](./img/dashboard_nginx_servers.png)
 
 - **NGINX Server**: Focus on a single NGINX server.
-  
+
   [<img src='./img/dashboard_nginx_server.png' width=200px>](./img/dashboard_nginx_server.png)  
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -47,9 +47,9 @@ This plugin requires:
  ##### RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09
 
  Run the following command to install the collectd plugin:
- ```
- yum install collectd-nginx
- ```
+
+         yum install collectd-nginx
+
  ##### Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://github.com/signalfx/integrations/tree/master/collectd).
@@ -59,9 +59,9 @@ This plugin requires:
 1. Modify the sample configuration file to provide values that make sense for your environment, as described in the header.
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 2:
- ```
- include '/path/to/10-nginx.conf'
- ```
+
+        include '/path/to/10-nginx.conf'
+
 1. Restart collectd.
 
 ### CONFIGURATION

--- a/collectd-postgresql/README.md
+++ b/collectd-postgresql/README.md
@@ -27,11 +27,11 @@ The configuration syntax of the PostgreSQL, DBI, and Oracle plugins is very simi
 ##### Built-in dashboards
 
 - **PostgreSQL Nodes**: Overview of data from all PostgreSQL nodes.
-  
+
   [<img src='./img/dashboard_postgresql_nodes.png' width=200px>](./img/dashboard_postgresql_nodes.png)
 
 - **PostgreSQL Node**: Focus on a single PostgreSQL node.
-  
+
   [<img src='./img/dashboard_postgresql_node.png' width=200px>](./img/dashboard_postgresql_node.png)  
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -50,9 +50,9 @@ This plugin requires:
 
  ##### RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09
  Run the following command to install this plugin:
- ```
- yum install collectd-postgresql
- ```
+
+         yum install collectd-postgresql
+
 1. Download SignalFx's [sample PostgreSQL configuration file](https://github.com/signalfx/integrations/blob/master/collectd-postgresql/10-postgresql.conf)
 
  **_Note:_** _if using a version of PostgreSQL older than 0.92 use_ [_this configuration file_](https://github.com/signalfx/integrations/blob/master/collectd-postgresql/10-postgresql_pre92.conf)
@@ -60,9 +60,9 @@ This plugin requires:
  Modify the sample configuration file to provide values that make sense for your environment, as described in the header.
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 2:
-```
-include '/path/to/10-postgresql.conf'
-```
+
+         include '/path/to/10-postgresql.conf'
+
 1. Restart collectd.
 
 Metrics from PostgreSQL will begin streaming into SignalFx, and new built-in dashboards will be created for you.

--- a/collectd-rabbitmq/README.md
+++ b/collectd-rabbitmq/README.md
@@ -24,11 +24,11 @@ The RabbitMQ plugin that collects statistics from RabbitMQ. The plugin uses the 
 ##### Built-in dashboards
 
 - **RabbitMQ**: Overview of data from all RabbitMQ nodes.
-  
+
   [<img src='./img/dashboard_rabbitmq.png' width=200px>](./img/dashboard_rabbitmq.png)
 
 - **RabbitMQ Node**: Focus on a single RabbitMQ node.
-  
+
   [<img src='./img/dashboard_rabbitmq_node.png' width=200px>](./img/dashboard_rabbitmq_node.png)  
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -51,9 +51,8 @@ This plugin requires:
 
  Run the following command to install the Python plugin for collectd:
 
- ```
- yum install collectd-python
- ```
+         yum install collectd-python
+
 
  **Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:**
 
@@ -70,9 +69,9 @@ This plugin requires:
  1. Provide values that make sense for your environment, as described [below](#configuration).
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 3:
- ```
- include '/path/to/10-rabbitmq.conf'
- ```
+
+         include '/path/to/10-rabbitmq.conf'
+
 1. Restart collectd.
 
 collectd will begin emitting metrics from RabbitMQ.

--- a/collectd-redis/README.md
+++ b/collectd-redis/README.md
@@ -29,19 +29,19 @@ You can capture any kind of Redis metrics like:
  * Uptime
  * Changes since last save
  * Replication delay (per slave)
- 
+
 #### FEATURES
 
 ##### Built-in dashboards
 
 - **Redis Instances**: Overview of data from all Redis instances.
- 
+
  [<img src='./img/dashboard_redis_instances.png' width=200px>](./img/dashboard_redis_instances.png)
 
 - **Redis Instance**: Focus on a single Redis instance.
- 
+
  [<img src='./img/dashboard_redis_instance.png' width=200px>](./img/dashboard_redis_instance.png)  
- 
+
 ### REQUIREMENTS AND DEPENDENCIES
 
 This plugin requires:
@@ -61,9 +61,9 @@ This plugin requires:
  ##### RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09
 
  Run the following command to install the Python plugin for collectd:
- ```
- yum install collectd-python
- ```
+
+         yum install collectd-python
+
  ##### Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://support.signalfx.com/hc/en-us/articles/208080123).
@@ -83,9 +83,9 @@ This plugin requires:
  1. Provide values that make sense for your environment, as described [below](#configuration).
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 4:
- ```
- include '/path/to/10-redis_(master or slave).conf'
- ```
+
+         include '/path/to/10-redis_(master or slave).conf'
+
 1. Restart collectd.
 
 collectd will begin emitting metrics to SignalFx.

--- a/collectd-riak/README.md
+++ b/collectd-riak/README.md
@@ -54,9 +54,7 @@ This plugin is included with [SignalFx's collectd package](https://support.signa
 
 1. Add the following line to `/etc/collectd.conf`, replacing the example path with the location of the configuration file:
 
- ```
- include '/path/to/10-riak.conf'
- ```
+          include '/path/to/10-riak.conf'
 
 1. Restart collectd.
 

--- a/collectd-varnish/README.md
+++ b/collectd-varnish/README.md
@@ -26,11 +26,11 @@ The Varnish collectd plugin collects metrics from varnish and sends them to Sign
 ##### Built-in dashboards
 
 - **Varnish (a)**: Overview of data from all Varnish servers.
-  
+
   [<img src='./img/dashboard_varnish_a.png' width=200px>](./img/dashboard_varnish_a.png)
 
 - **Varnish**: Focus on a single Varnish server.
-  
+
   [<img src='./img/dashboard_varnish.png' width=200px>](./img/dashboard_varnish.png)
 
 ### REQUIREMENTS AND DEPENDENCIES
@@ -51,17 +51,17 @@ The Varnish collectd plugin collects metrics from varnish and sends them to Sign
  ##### RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09
 
  Run the following command to install this plugin:
- ```
- yum install collectd-varnish
- ```
+
+         yum install collectd-varnish
+
 1. Download SignalFx's [sample varnish configuration file](https://github.com/signalfx/integrations/blob/master/collectd-varnish/10-varnish.conf)
 
  Modify the sample configuration file to provide values that make sense for your environment, as described in the header.
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 2:
- ```
- include '/path/to/10-varnish.conf'
- ```
+
+         include '/path/to/10-varnish.conf'
+
 1. Restart collectd.
 
 Metrics from Varnish will begin streaming into SignalFx, and new built-in dashboards will be created for you. Check the status of your new integration on the Integrations page.

--- a/collectd-zookeeper/README.md
+++ b/collectd-zookeeper/README.md
@@ -26,13 +26,13 @@ This is a collectd plugin for getting metrics and information from
 ##### Built-in dashboards
 
 - **Zookeeper Nodes**: Overview of data from all Zookeeper nodes.
-  
+
   [<img src='./img/dashboard_zookeeper_nodes.png' width=200px>](./img/dashboard_zookeeper_nodes.png)
 
 - **Zookeeper Node**: Focus on a single Zookeeper node.
-  
+
   [<img src='./img/dashboard_zookeeper_node.png' width=200px>](./img/dashboard_zookeeper_node.png)  
-  
+
 ### REQUIREMENTS AND DEPENDENCIES
 
 This plugin requires:
@@ -56,9 +56,9 @@ This plugin requires:
  ##### RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09
 
  Run the following command to install the Python plugin for collectd:
- ```
- yum install collectd-python
- ```
+
+         yum install collectd-python
+
  ##### Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
 
  This plugin is included with [SignalFx's collectd package](https://support.signalfx.com/hc/en-us/articles/208080123).
@@ -76,9 +76,9 @@ This plugin requires:
  1. Provide values that make sense for your environment, as described [below](#configuration).
 
 1. Add the following line to /etc/collectd.conf, replacing the example path with the location of the configuration file you downloaded in step 4:
- ```
- include '/path/to/20-zookeeper.conf'
- ```
+
+        include '/path/to/20-zookeeper.conf'
+
 1. Restart collectd.
 
 collectd will begin emitting metrics from Zookeeper.

--- a/collectd/README.md
+++ b/collectd/README.md
@@ -22,9 +22,9 @@ The [SignalFx collectd agent](https://github.com/signalfx/collectd) introduces t
 
 * **Increased Character limit:** We’ve increased the number of characters that can be used in dimension key-value pairs to 1024, up from 64. In practice, this allows you to send as many dimensions as you want.
 * **Buffer Flushing:** To ensure that metrics always arrive in a timely manner, we’ve added a timer to ensure that data is transmitted either when the data buffer is full or when a time limit is reached, whichever happens first. This capability is particularly useful if you are only collecting small quantities of time-sensitive metrics.
-* **HTTP Error Logging:** We’re providing greater visibility into how collectd itself is functioning, by logging HTTP codes from unsuccessful data transmissions by the `write_http` plugin, and by logging the name of every plugin that is loaded at startup. 
+* **HTTP Error Logging:** We’re providing greater visibility into how collectd itself is functioning, by logging HTTP codes from unsuccessful data transmissions by the `write_http` plugin, and by logging the name of every plugin that is loaded at startup.
 
-All changes have been submitted back to the [collectd project](http://collectd.org) for the benefit of the community at large. 
+All changes have been submitted back to the [collectd project](http://collectd.org) for the benefit of the community at large.
 
 ### REQUIREMENTS AND DEPENDENCIES
 
@@ -42,10 +42,10 @@ The SignalFx collectd agent is supported on the following operating systems:
 
 Sending data using collectd allows you to take advantage of SignalFx’s extensive collectd support.
 
-- The SignalFx Hosts page visualizes hosts that are monitored using the SignalFx collectd agent. 
+- The SignalFx Hosts page visualizes hosts that are monitored using the SignalFx collectd agent.
 - SignalFx provides built-in dashboards to show infrastructure data as reported by the SignalFx collectd agent.
 - SignalFx provides validated plugins for collectd to help you monitor specific software in your environment. Browse plugins that have been validated by SignalFx [here on Github](http://signalfx.github.io), or on the Integrations page in SignalFx.
-- The [SignalFx metadata plugin for collectd](../collectd-signalfx) is a plugin that enriches your data by sending metadata about your hosts to SignalFx. This plugin is included by default in SignalFx’s collectd packages. 
+- The [SignalFx metadata plugin for collectd](../collectd-signalfx) is a plugin that enriches your data by sending metadata about your hosts to SignalFx. This plugin is included by default in SignalFx’s collectd packages.
 
 ![](./img/collectdhostspage.png)
 
@@ -55,16 +55,16 @@ Sending data using collectd allows you to take advantage of SignalFx’s extensi
 
 #### Install with shell script
 
-SignalFx provides a shell script that you can use to install the SignalFx collectd agent, including important plugins. Follow these instructions to install the SignalFx collectd agent on a system for which you have administrator (sudo) privileges. 
+SignalFx provides a shell script that you can use to install the SignalFx collectd agent, including important plugins. Follow these instructions to install the SignalFx collectd agent on a system for which you have administrator (sudo) privileges.
 
 If you have already installed collectd on your own, this script will install the [SignalFx metadata plugin](../collectd-signalfx) and configure collectd to send metrics to SignalFx.
 
 **1. Download and run the script**
 
  Run the following command in your command-line, replacing `API_TOKEN` with your API token. To view the API token for your organization, open [your profile page in SignalFx](https://app.signalfx.com/#/myprofile) and click "Show" next to the API token for the corresponding organization.
- ```
- sudo curl -sSL https://dl.signalfx.com/collectd-install | bash -s API_TOKEN
- ```
+
+        sudo curl -sSL https://dl.signalfx.com/collectd-install | bash -s API_TOKEN
+
  This command will download and run the script. On startup, the script will ask you to confirm that you want to proceed.
 
 **2. Provide your hostname**
@@ -74,15 +74,15 @@ If you have already installed collectd on your own, this script will install the
  * Type `dns` and press enter to automatically collect this system's hostname from DNS.
  * Type `input` and press enter to provide the hostname yourself. When prompted, type in your desired hostname and press enter.
 
-When the script successfully completes, the SignalFx collectd agent starts up and begins reporting metrics to SignalFx. 
+When the script successfully completes, the SignalFx collectd agent starts up and begins reporting metrics to SignalFx.
 
 ##### Note: Additional installer options
 
-The instructions above apply to most installation scenarios. For more information on available configuration options for this script, please see complete documentation here on Github: https://github.com/signalfx/signalfx-collectd-installer/blob/master/README.md 
+The instructions above apply to most installation scenarios. For more information on available configuration options for this script, please see complete documentation here on Github: https://github.com/signalfx/signalfx-collectd-installer/blob/master/README.md
 
 ##### Note: Uninstalling from Mac OS X
 
-When the install script installs the SignalFx collectd agent on a Mac OS X system, an `uninstall.sh` script is laid down in the directory `/usr/local/share/collectd`. Run this script with administrative privileges to remove collectd and all related configuration from the host. Run the script with `–help` option for detailed instructions, including how to perform a dry run and keep configuration in place after uninstalling. 
+When the install script installs the SignalFx collectd agent on a Mac OS X system, an `uninstall.sh` script is laid down in the directory `/usr/local/share/collectd`. Run this script with administrative privileges to remove collectd and all related configuration from the host. Run the script with `–help` option for detailed instructions, including how to perform a dry run and keep configuration in place after uninstalling.
 
 #### Additional installation options
 
@@ -92,7 +92,7 @@ SignalFx supports a Chef cookbook that installs the SignalFx collectd agent and 
 
 ##### Puppet module: `signalfx/collectd`
 
-SignalFx provides Puppet modules to install the SignalFx collectd agent and important plugins. Access it here on Puppet Forge: 
+SignalFx provides Puppet modules to install the SignalFx collectd agent and important plugins. Access it here on Puppet Forge:
 https://forge.puppet.com/signalfx/collectd
 
 ##### Manual step-by-step installation
@@ -101,15 +101,15 @@ If you wish to manually complete the steps that SignalFx's shell script performs
 
 ### CONFIGURATION
 
-The SignalFx collectd agent is accompanied by a default configuration file, `collectd.conf`, that does not need to be modified in order to function. 
+The SignalFx collectd agent is accompanied by a default configuration file, `collectd.conf`, that does not need to be modified in order to function.
 
-An example configuration file for the SignalFx collectd agent can be found [here](./collectd.conf) in this repository. 
+An example configuration file for the SignalFx collectd agent can be found [here](./collectd.conf) in this repository.
 
 #### Using the SignalFx metrics proxy
 
-If instances of collectd are unable to transmit outside the network, the SignalFx metrics proxy can be used to receive connections from many instances of collectd, and forward transmissions to SignalFx using a single outgoing HTTP connection. This is suitable for environments in which transmissions exiting a network are highly restricted. 
+If instances of collectd are unable to transmit outside the network, the SignalFx metrics proxy can be used to receive connections from many instances of collectd, and forward transmissions to SignalFx using a single outgoing HTTP connection. This is suitable for environments in which transmissions exiting a network are highly restricted.
 
-[Click here to read more about the SignalFx metrics proxy](https://github.com/signalfx/integrations/tree/master/metricproxy). 
+[Click here to read more about the SignalFx metrics proxy](https://github.com/signalfx/integrations/tree/master/metricproxy).
 
 #### Transmitting through an existing HTTP proxy
 
@@ -125,7 +125,7 @@ export http_proxy="http://HTTP_PROXY:PROXY_PORT"
 export https_proxy="https://HTTPS_PROXY:PROXY_PORT"
 ```
 
-Replace `HTTP_PROXY` and `HTTPS_PROXY` with the hostname of the HTTP proxy to be used, and `PROXY_PORT` with the port at which to access it. 
+Replace `HTTP_PROXY` and `HTTPS_PROXY` with the hostname of the HTTP proxy to be used, and `PROXY_PORT` with the port at which to access it.
 
 ### LICENSE
 

--- a/win-statsd.net/README.md
+++ b/win-statsd.net/README.md
@@ -48,14 +48,14 @@ Alternatively, specify any or all of the configuration options.
 
 Or if readability is your thing:
 
- ```
+```
     $config = @{
         APIToken='yourtoken';
         SourceType='netbios';
         SampleInterval = '5s';
     }
     ./Install.ps1 $config
- ```
+```
 
 For hash values not supplied the following defaults are used. APIToken and SourceType are required.  
 


### PR DESCRIPTION
Using spaces to create code blocks rather than triple backticks, since you can use spaces within a numbering section without breaking the numbering.