### PR TITLE
Dimensionalize Elasticsearch thread pool metrics

### DIFF
--- a/collectd-elasticsearch/20-elasticsearch.conf
+++ b/collectd-elasticsearch/20-elasticsearch.conf
@@ -83,7 +83,7 @@
         Verbose false
         Cluster "elasticsearch"
         Indexes ["_all"]
-        EnableIndexStats false
+        EnableIndexStats true
         EnableClusterHealth true
         Interval 10
         IndexInterval 300

--- a/collectd-elasticsearch/dashboards/Page_Elasticsearch.json
+++ b/collectd-elasticsearch/dashboards/Page_Elasticsearch.json
@@ -1,5285 +1,2135 @@
 [ {
   "marshallScope" : 2
 }, {
+  "marshallId" : 1,
   "sf_description" : "Metrics about Elasticsearch.",
-  "sf_type" : "Service",
   "sf_service" : "ElasticSearch",
-  "marshallId" : 1
+  "sf_type" : "Service"
 }, {
-  "sf_page" : "Elasticsearch",
-  "sf_description" : "Dashboards about Elasticsearch.",
-  "sf_type" : "Page",
   "marshallId" : 2,
-  "marshallMemberOf" : [ 1 ]
+  "marshallMemberOf" : [ 1 ],
+  "sf_description" : "Dashboards about Elasticsearch.",
+  "sf_page" : "Elasticsearch",
+  "sf_type" : "Page"
 }, {
-  "sf_dashboard" : "Elasticsearch",
-  "sf_uiModel" : {
-    "widgets" : [ {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441323819642,
-        "id" : 1
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 3,
-        "id" : 2
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1443043692867,
-        "id" : 3
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441150718637,
-        "id" : 4
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 2,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1443032267071,
-        "id" : 5
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 4,
-        "id" : 6
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441215631067,
-        "id" : 7
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 2,
-        "id" : 8
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 1,
-        "id" : 9
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1442525326269,
-        "id" : 10
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 16,
-        "id" : 11
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 14,
-        "id" : 12
-      },
-      "row" : 4
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1442525196684,
-        "id" : 13
-      },
-      "row" : 4
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 5,
-        "id" : 14
-      },
-      "row" : 4
-    } ],
-    "version" : 1
-  },
-  "sf_discoverySelectors" : [ "sf_hostHasService:elasticsearch", "plugin:elasticsearch" ],
-  "sf_description" : "",
-  "sf_type" : "Dashboard",
-  "sf_discoveryQuery" : "plugin:elasticsearch",
   "marshallId" : 3,
-  "marshallMemberOf" : [ 2 ]
-}, {
-  "sf_chart" : "Merges/sec",
-  "sf_uiModel" : {
-    "revisionNumber" : 12,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "counter.indices.merges.total - Sum by plugin_instance",
-      "seriesData" : {
-        "metric" : "counter.indices.merges.total"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : null,
-        "visualization" : "area",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_12",
-    "chartMode" : "graph",
-    "relatedDetectors" : [ ],
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "merges / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "forcedResolution" : "0"
-    },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.merges.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1442525326269,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.merges.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "marshallId" : 4,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 16,
-    "allPlotConstructs" : [ ],
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "gauge.indices.store.size - Sum by plugin_instance",
-      "seriesData" : {
-        "metric" : "gauge.indices.store.size"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "gauge.indices.store.size - Sum by plugin_instance - Timeshift 1d",
-      "seriesData" : {
-        "metric" : "gauge.indices.store.size"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 86400000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TOPN",
-          "options" : {
-            "count" : 3
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "(A-B)*100/B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_16",
-    "chartMode" : "list",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "forcedResolution" : "0",
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "Size (bytes)",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 5,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.indices.store.size AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.store.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_16;B => find(query='(sf_metric:gauge.indices.store.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(offset=-86400000) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_16;_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK:!OUT->groupby()->groupby()->select(count=3):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_16->?B:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK",
-  "sf_description" : "last day",
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "marshallId" : 5,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Top Clusters by Index Growth %",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 16,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.store.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');B => find(query='(sf_metric:gauge.indices.store.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(offset=-86400000) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK:!OUT->groupby()->groupby()->select(count=3):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_16->?B:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK"
-}, {
-  "sf_chart" : "Top Clusters by Query Latency (ms)",
-  "sf_uiModel" : {
-    "revisionNumber" : 26,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "counter.indices.search.query-total",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-total"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : "MAX_ROLLUP",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "counter.indices.search.query-time",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-time"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : "MAX_ROLLUP",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "counter.indices.search.query-total - Timeshift 1h",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-total"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : "MAX_ROLLUP",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "counter.indices.search.query-time - Timeshift 1h",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-time"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : "MAX_ROLLUP",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "(B-D)/(A-C)",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "(B-D)/(A-C)",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 6,
-      "name" : "",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 99
-          }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TOPN",
-          "options" : {
-            "count" : 5
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "E",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 7,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_26",
-    "chartMode" : "list",
-    "relatedDetectors" : [ ],
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "forcedResolution" : "0",
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "Time (ms)",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "-value",
-      "disableThrottle" : false
-    },
-    "currentUniqueKey" : 14
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK=[?B,?D,?A,?C,!OUT]{(?B - ?D) / (?A - ?C)->!OUT};_SF_PLOT_KEY_##CHARTID##_6_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK=[?E,!OUT]{?E->!OUT};find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_26;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_26;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_26;_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_2_26->?B:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_26->?D:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_26->?C:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK:!OUT->groupby('plugin_instance')->stats:!p99->groupby()->groupby()->select(count=5):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_6_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_5_26->?E:_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_description" : "p99 latency over the last hour",
-  "sf_chartIndex" : 1443032267071,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK=[?B,?D,?A,?C,!OUT]{(?B - ?D) / (?A - ?C)->!OUT};_SF_PLOT_KEY_##CHARTID##_6_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK=[?E,!OUT]{?E->!OUT};find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_2_26->?B:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_26->?D:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_26->?C:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK:!OUT->groupby('plugin_instance')->stats:!p99->groupby()->groupby()->select(count=5):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_6_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_5_26->?E:_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK",
-  "marshallId" : 6,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Cache Size (bytes)",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 22,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Filter Cache",
-      "seriesData" : {
-        "metric" : "gauge.indices.cache.filter.size"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Field Cache",
-      "seriesData" : {
-        "metric" : "gauge.indices.cache.field.size"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_22",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "sortPreference" : "",
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "size (bytes)",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "useKMG2" : true,
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 4,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_22=id(report=1);A => find(query='(sf_metric:gauge.indices.cache.filter.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_22 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');B => find(query='(sf_metric:gauge.indices.cache.field.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_22 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1442525196684,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_22=id(report=1);A => find(query='(sf_metric:gauge.indices.cache.filter.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_22 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');B => find(query='(sf_metric:gauge.indices.cache.field.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_22 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22')",
-  "marshallId" : 7,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 17,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "gauge.indices.docs.count - Sum by plugin_instance",
-      "seriesData" : {
-        "metric" : "gauge.indices.docs.count"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "gauge.indices.docs.count - Sum by plugin_instance - Timeshift 1h",
-      "seriesData" : {
-        "metric" : "gauge.indices.docs.count"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "Growth rate",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "(A-B)*100/B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_17",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : false,
-      "absoluteEnd" : null,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "growth %",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 5,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.gauge.indices.docs.count AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_17;B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(offset=-3600000) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_17;_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_1_17->?A:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_17->?B:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK",
-  "sf_description" : "last hour",
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "marshallId" : 8,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Document Growth %",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(offset=-3600000) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_1_17->?A:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_17->?B:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK"
-}, {
-  "sf_chart" : "Search Requests",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 11,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "counter.indices.search.query-total - Sum by plugin_instance",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-total"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_11",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "requests / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 3,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.search.query-total AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 4,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-  "marshallId" : 9,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "# Hosts/Clusters",
-  "sf_uiModel" : {
-    "revisionNumber" : 10,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "# hosts",
-      "seriesData" : {
-        "metric" : "counter.indices.indexing.index-total"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "COUNT",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "# clusters",
-      "seriesData" : {
-        "metric" : "counter.indices.indexing.index-total"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "COUNT",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_10",
-    "chartMode" : "list",
-    "relatedDetectors" : [ ],
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "id" : "yAxis0",
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ],
-      "sortPreference" : "-value"
-    },
-    "currentUniqueKey" : 4
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_2_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441323819642,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_2_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
-  "marshallId" : 10,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Top Clusters by Search Requests",
-  "sf_uiModel" : {
-    "revisionNumber" : 12,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-total"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TOPN",
-          "options" : {
-            "count" : 3
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#007c1d",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_12",
-    "chartMode" : "list",
-    "relatedDetectors" : [ ],
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "id" : "yAxis0",
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ],
-      "sortPreference" : ""
-    },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=3):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441150718637,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=3):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "marshallId" : 11,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Top Clusters by Indexing Requests",
-  "sf_uiModel" : {
-    "revisionNumber" : 12,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "",
-      "seriesData" : {
-        "metric" : "counter.indices.indexing.index-total"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TOPN",
-          "options" : {
-            "count" : 3
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#876ff3",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_12",
-    "chartMode" : "list",
-    "relatedDetectors" : [ ],
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 2,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "id" : "yAxis0",
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ],
-      "sortPreference" : ""
-    },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=3):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441215631067,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=3):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "marshallId" : 12,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Indexing Requests",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 12,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "counter.indices.indexing.index-total - Sum by plugin_instance",
-      "seriesData" : {
-        "metric" : "counter.indices.indexing.index-total"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_12",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "requests / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 3,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.indexing.index-total AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 2,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "marshallId" : 13,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 23,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "gauge.jvm.mem.heap-used"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "gauge.jvm.mem.heap-committed"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "A*100/G",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "A*100/B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "min",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MIN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "p10",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 10
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0dba8f",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 6,
-      "name" : "p50",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 50
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#00b9ff",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 7,
-      "name" : "p90",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 90
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#f47e00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 8,
-      "name" : "max",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#bd468d",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 9,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_23",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : true,
-      "absoluteEnd" : null,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : 110,
-        "label" : "% used",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      }, {
-        "max" : null,
-        "label" : "Used %",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        },
-        "min" : null
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 15,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_23=id(report=1);D => _SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_23=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_23=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_23=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_23=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_23;B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_23;_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_1_23->?A:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_23->?B:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK",
-  "sf_description" : "percentile distribution",
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "marshallId" : 14,
-  "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Heap %",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 3,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_23=id(report=1);D => _SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_23=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_23=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_23=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_23=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_23 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_23 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_1_23->?A:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_23->?B:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK"
-}, {
-  "sf_chart" : "GC Time %",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 24,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "counter.jvm.gc.time"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "counter.jvm.uptime"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "counter.jvm.gc.time"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "counter.jvm.uptime"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "min",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "(A-C)*100/(B-D)",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 6,
-      "name" : "min",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MIN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 7,
-      "name" : "p10",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 10
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0dba8f",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 8,
-      "name" : "p50",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 50
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#00b9ff",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 9,
-      "name" : "p90",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 90
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#f47e00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 10,
-      "name" : "max",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#bd468d",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 11,
-      "name" : "New Plot",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "metricDefinition" : { },
-      "type" : "plot",
-      "seriesData" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_24",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "% gc time",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      }, {
-        "max" : null,
-        "label" : "Used %",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        },
-        "min" : null
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 25,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_24=id(report=1);R => _SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK=[?A,?O,?G,?P,!OUT]{(?A - ?O) * 100 / (?G - ?P)->!OUT};_SF_PLOT_KEY_##CHARTID##_19_24=id(report=1);S => _SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_20_24=id(report=1);T => _SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_21_24=id(report=1);U => _SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_22_24=id(report=1);V => _SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_23_24=id(report=1);W => _SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24;G => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_24;O => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_15_24;P => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_16_24;_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_18_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_18_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_15_24->?O:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24->?G:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_16_24->?P:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_19_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_19_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_20_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_20_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_21_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_21_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_22_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_22_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_23_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_23_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_description" : "percentile distribution over the last hour",
-  "sf_chartIndex" : 1443043692867,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_24=id(report=1);R => _SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK=[?A,?O,?G,?P,!OUT]{(?A - ?O) * 100 / (?G - ?P)->!OUT};_SF_PLOT_KEY_##CHARTID##_19_24=id(report=1);S => _SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_20_24=id(report=1);T => _SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_21_24=id(report=1);U => _SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_22_24=id(report=1);V => _SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_23_24=id(report=1);W => _SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');G => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');O => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_15_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_15_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');P => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_16_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_16_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_18_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_18_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_15_24->?O:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24->?G:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_16_24->?P:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_19_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_19_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_20_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_20_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_21_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_21_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_22_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_22_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_23_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_23_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK",
-  "marshallId" : 15,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Thread Pool Rejections",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 9,
-    "allPlotConstructs" : [ ],
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Bulk",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.bulk.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Flush",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.flush.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Generic",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.generic.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "Get",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.get.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 5,
-      "name" : "Index",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.index.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 6,
-      "name" : "Merge",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.merge.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 7,
-      "name" : "Optimize",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.optimize.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 8,
-      "name" : "Refresh",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.refresh.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 9,
-      "name" : "Search",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.search.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 10,
-      "name" : "Snapshot",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.snapshot.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 11,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_9",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "rejections / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 12,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.bulk.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_3',metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.flush.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_2_3',metric='_SF_PLOT_KEY_##CHARTID##_2_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.generic.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_3_3',metric='_SF_PLOT_KEY_##CHARTID##_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.get.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_4_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_4_3',metric='_SF_PLOT_KEY_##CHARTID##_4_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.index.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_5_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_5_3',metric='_SF_PLOT_KEY_##CHARTID##_5_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.merge.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_6_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_6_3',metric='_SF_PLOT_KEY_##CHARTID##_6_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.optimize.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_7_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_7_3',metric='_SF_PLOT_KEY_##CHARTID##_7_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.refresh.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_8_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_8_3',metric='_SF_PLOT_KEY_##CHARTID##_8_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.search.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_9_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_9_3',metric='_SF_PLOT_KEY_##CHARTID##_9_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.snapshot.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_10_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_10_3',metric='_SF_PLOT_KEY_##CHARTID##_10_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_9=id(report=1);A => find(query='(sf_metric:counter.thread_pool.bulk.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');B => find(query='(sf_metric:counter.thread_pool.flush.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');C => find(query='(sf_metric:counter.thread_pool.generic.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');D => find(query='(sf_metric:counter.thread_pool.get.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');E => find(query='(sf_metric:counter.thread_pool.index.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');F => find(query='(sf_metric:counter.thread_pool.merge.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_6_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');G => find(query='(sf_metric:counter.thread_pool.optimize.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_7_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');H => find(query='(sf_metric:counter.thread_pool.refresh.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');I => find(query='(sf_metric:counter.thread_pool.search.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');J => find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 5,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_9=id(report=1);A => find(query='(sf_metric:counter.thread_pool.bulk.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');B => find(query='(sf_metric:counter.thread_pool.flush.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');C => find(query='(sf_metric:counter.thread_pool.generic.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');D => find(query='(sf_metric:counter.thread_pool.get.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');E => find(query='(sf_metric:counter.thread_pool.index.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');F => find(query='(sf_metric:counter.thread_pool.merge.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_6_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');G => find(query='(sf_metric:counter.thread_pool.optimize.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_7_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');H => find(query='(sf_metric:counter.thread_pool.refresh.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');I => find(query='(sf_metric:counter.thread_pool.search.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');J => find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-  "marshallId" : 16,
-  "marshallMemberOf" : [ 3 ]
-}, {
-  "sf_chart" : "Deleted Documents %",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 21,
-    "allPlotConstructs" : [ ],
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ ],
-      "uniqueKey" : 1,
-      "name" : "gauge.indices.docs.deleted - Sum by plugin_instance",
-      "seriesData" : {
-        "metric" : "gauge.indices.docs.deleted"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "gauge.indices.docs.count - Sum by plugin_instance",
-      "seriesData" : {
-        "metric" : "gauge.indices.docs.count"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "% of Deleted Documents",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "A*100/B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_21",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : false,
-      "absoluteEnd" : null,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "deleted %",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "disableThrottle" : false
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 5,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.docs.deleted AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_21;B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_21;_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 14,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.docs.deleted AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK",
-  "marshallId" : 17,
-  "marshallMemberOf" : [ 3 ]
-}, {
+  "marshallMemberOf" : [ 2 ],
+  "sf_dashboard" : "Elasticsearch Node",
+  "sf_description" : "",
+  "sf_discoveryQuery" : "plugin:elasticsearch",
+  "sf_discoverySelectors" : [ "_exists_:host" ],
   "sf_filterAlias" : {
     "variables" : [ {
-      "dimension" : "host",
       "alias" : "host",
-      "globalScope" : true,
-      "required" : true,
       "description" : "Elasticsearch node",
-      "restricted" : false,
-      "preferredSuggestions" : [ ]
+      "dimension" : "host",
+      "globalScope" : true,
+      "preferredSuggestions" : [ ],
+      "required" : true,
+      "restricted" : false
     } ]
   },
-  "sf_dashboard" : "Elasticsearch Node",
-  "sf_uiModel" : {
-    "widgets" : [ {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441143740915,
-        "id" : 1
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441145050363,
-        "id" : 2
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 1,
-        "id" : 3
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 3,
-        "id" : 4
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 2,
-        "id" : 5
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 4,
-        "id" : 6
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 8,
-        "id" : 7
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440702516829,
-        "id" : 8
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 7,
-        "id" : 9
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440632194739,
-        "id" : 10
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1440720485244,
-        "id" : 11
-      },
-      "row" : 3
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 5,
-        "id" : 12
-      },
-      "row" : 3
-    } ],
-    "version" : 1
-  },
-  "sf_description" : "",
   "sf_type" : "Dashboard",
-  "marshallId" : 18,
-  "marshallMemberOf" : [ 2 ]
-}, {
-  "sf_chart" : "Indexing Requests/sec",
   "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 11,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "requests/sec",
-      "seriesData" : {
-        "metric" : "counter.indices.indexing.index-total"
+    "version" : 1,
+    "widgets" : [ {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1441143740915,
+        "id" : 1,
+        "name" : "",
+        "type" : "chart"
       },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
     }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_11",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "requests/sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 3,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.indexing.index-total AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441145050363,
+        "id" : 2,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1,
+        "id" : 3,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 3,
+        "id" : 4,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 2,
+        "id" : 5,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 4,
+        "id" : 6,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 8,
+        "id" : 7,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1440702516829,
+        "id" : 8,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 7,
+        "id" : 9,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1440632194739,
+        "id" : 10,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1440720485244,
+        "id" : 11,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 5,
+        "id" : 12,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    } ]
+  }
+}, {
+  "marshallId" : 4,
+  "marshallMemberOf" : [ 3 ],
   "sf_cacheProgram" : false,
-  "sf_chartIndex" : 2,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-  "marshallId" : 19,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_chart" : "Memory Heap Size (bytes)",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 21,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "used",
-      "seriesData" : {
-        "metric" : "gauge.jvm.mem.heap-used"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "committed",
-      "seriesData" : {
-        "metric" : "gauge.jvm.mem.heap-committed"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#007c1d",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_21",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "useKMG2" : true,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "size (bytes)",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 7,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')",
-  "sf_cacheProgram" : false,
-  "sf_description" : "",
-  "sf_chartIndex" : 3,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')",
-  "marshallId" : 20,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_chart" : "Requests/sec",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 13,
-    "allPlotConstructs" : [ ],
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Search",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-total"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Index",
-      "seriesData" : {
-        "metric" : "counter.indices.indexing.index-total"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Get",
-      "seriesData" : {
-        "metric" : "counter.indices.get.total"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_13",
-    "chartMode" : "list",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "id" : "yAxis0",
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ],
-      "sortPreference" : "-value",
-      "forcedResolution" : "0"
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 5,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.indices.store.size AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');B => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');C => find(query='(sf_metric:counter.indices.get.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-  "sf_cacheProgram" : true,
-  "sf_chartIndex" : 1441143740915,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 12000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');B => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');C => find(query='(sf_metric:counter.indices.get.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-  "marshallId" : 21,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_chart" : "Merges/sec",
-  "sf_uiModel" : {
-    "revisionNumber" : 11,
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "# merges",
-      "seriesData" : {
-        "metric" : "counter.indices.merges.total"
-      },
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : null,
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_11",
-    "chartMode" : "graph",
-    "relatedDetectors" : [ ],
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "merges / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "forcedResolution" : "0"
-    },
-    "currentUniqueKey" : 3
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:counter.indices.merges.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440702516829,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:counter.indices.merges.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
-  "marshallId" : 22,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 24,
-    "allPlotConstructs" : [ ],
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "counter.indices.search.query-total",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-total"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "counter.indices.search.query-time",
-      "seriesData" : {
-        "metric" : "counter.indices.search.query-time"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "A - Timeshift 1m",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 60000
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "B - Timeshift 1m",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 60000
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "01-min",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "(B-D)/(A-C)",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 6,
-      "name" : "A - Timeshift 5m",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 300000
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 7,
-      "name" : "B - Timeshift 5m",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 300000
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 8,
-      "name" : "05-min",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "(B-G)/(A-F)",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 9,
-      "name" : "A - Timeshift 1h",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 10,
-      "name" : "B - Timeshift 1h",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 11,
-      "name" : "60-min",
-      "seriesData" : { },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "(B-J)/(A-I)",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 12,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_24",
-    "chartMode" : "list",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 2,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
-        "id" : "yAxis0",
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ],
-      "sortPreference" : "+sf_metric",
-      "forcedResolution" : "0"
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 23,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.indices.store.size AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_5_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK=[?B,?D,?A,?C,!OUT]{(?B - ?D) / (?A - ?C)->!OUT};_SF_PLOT_KEY_##CHARTID##_6_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK=[?B,?G,?A,?F,!OUT]{(?B - ?G) / (?A - ?F)->!OUT};_SF_PLOT_KEY_##CHARTID##_9_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_10_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_11_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK=[?B,?J,?A,?I,!OUT]{(?B - ?J) / (?A - ?I)->!OUT};find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-60000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3;_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3->?A:_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-60000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4;_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_4_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4->?B:_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_5_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_24->?D:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-300000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6;_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6->?A:_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-300000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7;_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7->?B:_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_8_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24->?G:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_24->?F:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9;_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_9_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9->?A:_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10;_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_10_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_10_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10->?B:_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_11_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_11_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_10_24->?J:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_24->?I:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK",
-  "sf_description" : "",
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "marshallId" : 23,
-  "marshallMemberOf" : [ 18 ],
-  "sf_chart" : "Average Query Latency (ms)",
-  "sf_cacheProgram" : true,
-  "sf_chartIndex" : 1441145050363,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 12000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_5_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK=[?B,?D,?A,?C,!OUT]{(?B - ?D) / (?A - ?C)->!OUT};_SF_PLOT_KEY_##CHARTID##_6_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK=[?B,?G,?A,?F,!OUT]{(?B - ?G) / (?A - ?F)->!OUT};_SF_PLOT_KEY_##CHARTID##_9_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_10_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_11_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK=[?B,?J,?A,?I,!OUT]{(?B - ?J) / (?A - ?I)->!OUT};find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-60000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3;_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3->?A:_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-60000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4;_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_4_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4->?B:_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_5_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_24->?D:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-300000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6;_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6->?A:_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-300000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7;_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7->?B:_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_8_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24->?G:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_24->?F:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9;_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_9_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9->?A:_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10;_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_10_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_10_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10->?B:_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_11_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_11_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_10_24->?J:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_24->?I:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK"
-}, {
   "sf_chart" : "Active Merges",
+  "sf_chartIndex" : 1440720485244,
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:gauge.indices.merges.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
   "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
     "allDetectorDecorators" : [ ],
-    "revisionNumber" : 12,
     "allPlotConstructs" : [ ],
-    "chartType" : "line",
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.gauge.process.open_file_descriptors AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_4',metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')" ],
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
+      "configuration" : {
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "gauge.indices.merges.current",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
       "seriesData" : {
         "metric" : "gauge.indices.merges.current"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#f47e00",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
       "type" : "plot",
+      "uniqueKey" : 1,
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "New Plot",
+      "queryItems" : [ ],
       "seriesData" : { },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "type" : "plot",
+      "uniqueKey" : 2,
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_12",
     "chartMode" : "single",
+    "chartType" : "line",
     "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
+      "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : false,
+      "forcedResolution" : "0",
       "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
         "max" : null,
         "min" : null,
-        "id" : "yAxis0",
         "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
         }
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
+      } ]
     },
-    "relatedDetectors" : [ ],
     "currentUniqueKey" : 3,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.gauge.process.open_file_descriptors AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_4',metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:gauge.indices.merges.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440720485244,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:gauge.indices.merges.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "marshallId" : 24,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_chart" : "Search Requests/sec",
-  "sf_uiModel" : {
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 12,
     "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_12"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:gauge.indices.merges.current AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')"
+}, {
+  "marshallId" : 5,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : true,
+  "sf_chart" : "Document Growth Rate %",
+  "sf_chartIndex" : 1,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 12000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_6_20=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK=[?A,?C,!OUT]{(?A - ?C) * 100 / ?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_20=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK=[?A,?D,!OUT]{(?A - ?D) * 100 / ?D->!OUT};A => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_20;B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-3600000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_20;C => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-86400000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_20;D => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-604800000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_20;_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_20->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_20->?B:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_20->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_20->?C:_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_20->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_20->?D:_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
-    "revisionNumber" : 9,
     "allPlotConstructs" : [ ],
-    "chartType" : "area",
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.gauge.indices.docs.count AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
       } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Total",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.docs.count"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Total",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.docs.count"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Total",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.docs.count"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 604800000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Total",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.docs.count"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "(A-B)*100/B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "last hour",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "(A-C)*100/C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "last day",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "(A-D)*100/D",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "last week",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 7,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 8,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 4,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 13,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 20,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_20"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_6_20=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK=[?A,?C,!OUT]{(?A - ?C) * 100 / ?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_20=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK=[?A,?D,!OUT]{(?A - ?D) * 100 / ?D->!OUT};A => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-3600000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');C => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-86400000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');D => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-604800000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_20->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_20->?B:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_20->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_20->?C:_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_20->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_20->?D:_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK"
+}, {
+  "marshallId" : 6,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Indexing Requests/sec",
+  "sf_chartIndex" : 2,
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.indexing.index-total AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "requests/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.indexing.index-total"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "requests/sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_11"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')"
+}, {
+  "marshallId" : 7,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Search Requests/sec",
+  "sf_chartIndex" : 4,
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.search.query-total AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "requests/sec",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
       "seriesData" : {
         "metric" : "counter.indices.search.query-total"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
       "type" : "plot",
+      "uniqueKey" : 1,
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 2,
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "New Plot",
+      "queryItems" : [ ],
       "seriesData" : { },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "type" : "plot",
+      "uniqueKey" : 2,
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_9",
     "chartMode" : "graph",
+    "chartType" : "area",
     "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
+      "absoluteEnd" : null,
       "absoluteStart" : null,
-      "stackedChart" : false,
       "colorByMetric" : false,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "requests/sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 3,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.search.query-total AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 4,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-  "marshallId" : 25,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_chart" : "Cache Sizes (bytes)",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 21,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "filter cache size",
-      "seriesData" : {
-        "metric" : "gauge.indices.cache.filter.size"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "field cache size",
-      "seriesData" : {
-        "metric" : "gauge.indices.cache.field.size"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_21",
-    "chartMode" : "graph",
-    "chartconfig" : {
       "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "useKMG2" : true,
-      "colorByMetric" : true,
       "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
+        "id" : "yAxis0",
+        "label" : "requests/sec",
         "max" : null,
-        "label" : "size (bytes)",
+        "min" : 0,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
+        }
+      } ]
     },
+    "currentUniqueKey" : 3,
     "relatedDetectors" : [ ],
-    "currentUniqueKey" : 4,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);A => find(query='(sf_metric:gauge.indices.cache.filter.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.indices.cache.field.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1440632194739,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);A => find(query='(sf_metric:gauge.indices.cache.filter.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.indices.cache.field.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')",
-  "marshallId" : 26,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_chart" : "Thread Pool Rejections",
-  "sf_uiModel" : {
+    "revisionNumber" : 9,
     "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_9"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')"
+}, {
+  "marshallId" : 8,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : true,
+  "sf_chart" : "Average Query Latency (ms)",
+  "sf_chartIndex" : 1441145050363,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 12000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_5_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK=[?B,?D,?A,?C,!OUT]{(?B - ?D) / (?A - ?C)->!OUT};_SF_PLOT_KEY_##CHARTID##_6_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK=[?B,?G,?A,?F,!OUT]{(?B - ?G) / (?A - ?F)->!OUT};_SF_PLOT_KEY_##CHARTID##_9_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_10_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_11_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK=[?B,?J,?A,?I,!OUT]{(?B - ?J) / (?A - ?I)->!OUT};find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-60000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3;_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3->?A:_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-60000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4;_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_4_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4->?B:_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_5_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_24->?D:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-300000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6;_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6->?A:_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-300000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7;_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7->?B:_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_8_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24->?G:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_24->?F:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9;_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_9_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9->?A:_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10;_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_10_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_10_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10->?B:_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_11_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_11_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_10_24->?J:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_24->?I:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
-    "revisionNumber" : 12,
     "allPlotConstructs" : [ ],
-    "chartType" : "area",
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.indices.store.size AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
     "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.indices.search.query-total",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-total"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 1,
-      "name" : "Bulk",
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.indices.search.query-time",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-time"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 60000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "A - Timeshift 1m",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 60000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "B",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "B - Timeshift 1m",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "(B-D)/(A-C)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "01-min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 300000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "A - Timeshift 5m",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 300000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "B",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "B - Timeshift 5m",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 7,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "(B-G)/(A-F)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "05-min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 8,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "A - Timeshift 1h",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 9,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "B",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "B - Timeshift 1h",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 10,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "(B-J)/(A-I)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "60-min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 11,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 12,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 2,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "+sf_metric",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 23,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 24,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_24"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_4_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_5_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK=[?B,?D,?A,?C,!OUT]{(?B - ?D) / (?A - ?C)->!OUT};_SF_PLOT_KEY_##CHARTID##_6_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_8_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK=[?B,?G,?A,?F,!OUT]{(?B - ?G) / (?A - ?F)->!OUT};_SF_PLOT_KEY_##CHARTID##_9_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_10_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_11_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK=[?B,?J,?A,?I,!OUT]{(?B - ?J) / (?A - ?I)->!OUT};find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-60000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3;_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR3->?A:_SF_PLOT_KEY_##CHARTID##_3_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-60000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4;_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_4_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR4->?B:_SF_PLOT_KEY_##CHARTID##_4_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_5_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_24->?D:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_24->?C:_SF_PLOT_KEY_##CHARTID##_5_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-300000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6;_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR6->?A:_SF_PLOT_KEY_##CHARTID##_6_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-300000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7;_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR7->?B:_SF_PLOT_KEY_##CHARTID##_7_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_8_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24->?G:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_24->?F:_SF_PLOT_KEY_##CHARTID##_8_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9;_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_9_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_9_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24_TIMESHIFTFOR9->?A:_SF_PLOT_KEY_##CHARTID##_9_24_MACROBLOCK;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10;_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_10_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_10_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24_TIMESHIFTFOR10->?B:_SF_PLOT_KEY_##CHARTID##_10_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK:!OUT->groupby()->stats:!mean->_SF_PLOT_KEY_##CHARTID##_11_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_11_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_2_24->?B:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_10_24->?J:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_9_24->?I:_SF_PLOT_KEY_##CHARTID##_11_24_MACROBLOCK"
+}, {
+  "marshallId" : 9,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Merges/sec",
+  "sf_chartIndex" : 1440702516829,
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:counter.indices.merges.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "# merges",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.merges.total"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "merges / sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11,
+    "uiHelperValue" : "##CHARTID##_11"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:counter.indices.merges.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin_instance:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')"
+}, {
+  "marshallId" : 10,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : true,
+  "sf_chart" : "GC Time %",
+  "sf_chartIndex" : 8,
+  "sf_description" : "last hour",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 12000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_7_18=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK=[?A,?E,?B,?F,!OUT]{(?A - ?E) * 100 / (?B - ?F)->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18;B => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18;find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5;_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6;_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6->?B:_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_18->?E:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_18->?F:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.jvm.gc.time AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "GC time",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.gc.time"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.jvm.uptime",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.uptime"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "A - Timeshift 1h",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "B",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "B - Timeshift 1h",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "(A-C)*100/(B-D)",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "(A-E)*100/(B-F)",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 6,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "gc time %",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 9,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 18,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_18"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_7_18=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK=[?A,?E,?B,?F,!OUT]{(?A - ?E) * 100 / (?B - ?F)->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');B => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5;_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6;_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6->?B:_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_18->?E:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_18->?F:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK"
+}, {
+  "marshallId" : 11,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Thread Pool Rejections",
+  "sf_chartIndex" : 5,
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_13=id(report=1);find(query='(sf_metric:counter.thread_pool.bulk.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.flush.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.generic.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_3_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.get.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_4_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.index.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_5_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.merge.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_6_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.optimize.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_7_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.refresh.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_8_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.search.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_9_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_10_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('thread_pool') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_11_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_11_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.bulk.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_3',metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.flush.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_2_3',metric='_SF_PLOT_KEY_##CHARTID##_2_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.generic.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_3_3',metric='_SF_PLOT_KEY_##CHARTID##_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.get.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_4_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_4_3',metric='_SF_PLOT_KEY_##CHARTID##_4_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.index.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_5_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_5_3',metric='_SF_PLOT_KEY_##CHARTID##_5_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.merge.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_6_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_6_3',metric='_SF_PLOT_KEY_##CHARTID##_6_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.optimize.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_7_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_7_3',metric='_SF_PLOT_KEY_##CHARTID##_7_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.refresh.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_8_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_8_3',metric='_SF_PLOT_KEY_##CHARTID##_8_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.search.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_9_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_9_3',metric='_SF_PLOT_KEY_##CHARTID##_9_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.snapshot.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_10_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_10_3',metric='_SF_PLOT_KEY_##CHARTID##_10_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#999999",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Bulk rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
       "seriesData" : {
         "metric" : "counter.thread_pool.bulk.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Flush rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 2,
-      "name" : "Flush",
       "seriesData" : {
         "metric" : "counter.thread_pool.flush.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Generic rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 3,
-      "name" : "Generic",
       "seriesData" : {
         "metric" : "counter.thread_pool.generic.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#6ca2b7",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Get rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 4,
-      "name" : "Get",
       "seriesData" : {
         "metric" : "counter.thread_pool.get.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Index rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 5,
-      "name" : "Index",
       "seriesData" : {
         "metric" : "counter.thread_pool.index.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Merge rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 6,
-      "name" : "Merge",
       "seriesData" : {
         "metric" : "counter.thread_pool.merge.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 6,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e5b312",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Optimize rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 7,
-      "name" : "Optimize",
       "seriesData" : {
         "metric" : "counter.thread_pool.optimize.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Refresh rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 8,
-      "name" : "Refresh",
       "seriesData" : {
         "metric" : "counter.thread_pool.refresh.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 8,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Search rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 9,
-      "name" : "Search",
       "seriesData" : {
         "metric" : "counter.thread_pool.search.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 9,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#876ff3",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Snapshot rejections",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 10,
-      "name" : "Snapshot",
       "seriesData" : {
         "metric" : "counter.thread_pool.snapshot.rejected"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 11,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "thread_pool"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
       "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "rejections by thread pool",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.rejected",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
       "type" : "plot",
+      "uniqueKey" : 11,
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 12,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_12",
     "chartMode" : "graph",
+    "chartType" : "area",
     "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
+      "absoluteEnd" : null,
       "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
       "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
+        "id" : "yAxis0",
         "label" : "rejections / sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
+        }
+      } ]
     },
+    "currentUniqueKey" : 13,
     "relatedDetectors" : [ ],
-    "currentUniqueKey" : 12,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.bulk.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_3',metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.flush.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_2_3',metric='_SF_PLOT_KEY_##CHARTID##_2_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.generic.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_3_3',metric='_SF_PLOT_KEY_##CHARTID##_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.get.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_4_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_4_3',metric='_SF_PLOT_KEY_##CHARTID##_4_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.index.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_5_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_5_3',metric='_SF_PLOT_KEY_##CHARTID##_5_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.merge.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_6_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_6_3',metric='_SF_PLOT_KEY_##CHARTID##_6_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.optimize.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_7_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_7_3',metric='_SF_PLOT_KEY_##CHARTID##_7_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.refresh.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_8_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_8_3',metric='_SF_PLOT_KEY_##CHARTID##_8_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.search.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_9_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_9_3',metric='_SF_PLOT_KEY_##CHARTID##_9_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.snapshot.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_10_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_10_3',metric='_SF_PLOT_KEY_##CHARTID##_10_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_12=id(report=1);A => find(query='(sf_metric:counter.thread_pool.bulk.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');B => find(query='(sf_metric:counter.thread_pool.flush.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');C => find(query='(sf_metric:counter.thread_pool.generic.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');D => find(query='(sf_metric:counter.thread_pool.get.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');E => find(query='(sf_metric:counter.thread_pool.index.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');F => find(query='(sf_metric:counter.thread_pool.merge.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_6_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');G => find(query='(sf_metric:counter.thread_pool.optimize.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');H => find(query='(sf_metric:counter.thread_pool.refresh.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_8_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');I => find(query='(sf_metric:counter.thread_pool.search.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_9_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');J => find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_10_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 5,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_12=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_12=id(report=1);A => find(query='(sf_metric:counter.thread_pool.bulk.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');B => find(query='(sf_metric:counter.thread_pool.flush.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');C => find(query='(sf_metric:counter.thread_pool.generic.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');D => find(query='(sf_metric:counter.thread_pool.get.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');E => find(query='(sf_metric:counter.thread_pool.index.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_5_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');F => find(query='(sf_metric:counter.thread_pool.merge.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_6_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');G => find(query='(sf_metric:counter.thread_pool.optimize.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');H => find(query='(sf_metric:counter.thread_pool.refresh.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_8_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');I => find(query='(sf_metric:counter.thread_pool.search.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_9_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12');J => find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_10_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
-  "marshallId" : 27,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_chart" : "File Descriptors and Segments",
-  "sf_uiModel" : {
+    "revisionNumber" : 13,
     "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_13"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_13=id(report=1);find(query='(sf_metric:counter.thread_pool.bulk.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.flush.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.generic.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_3_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.get.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_4_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.index.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_5_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.merge.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_6_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.optimize.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_7_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.refresh.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_8_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.search.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_9_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> _SF_PLOT_KEY_##CHARTID##_10_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');find(query='(sf_metric:counter.thread_pool.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('thread_pool') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_11_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_11_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')"
+}, {
+  "marshallId" : 12,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "File Descriptors and Segments",
+  "sf_chartIndex" : 7,
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);A => find(query='(sf_metric:gauge.process.open_file_descriptors AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_16 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');B => find(query='(sf_metric:gauge.indices.segments.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_16 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
-    "revisionNumber" : 16,
     "allPlotConstructs" : [ ],
-    "chartType" : "column",
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.gauge.process.open_file_descriptors AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_4',metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')" ],
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "# file descriptors",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
       "seriesData" : {
         "metric" : "gauge.process.open_file_descriptors"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
       "type" : "plot",
+      "uniqueKey" : 1,
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "# segments",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
       "seriesData" : {
         "metric" : "gauge.indices.segments.count"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 1,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0077c2",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
       "type" : "plot",
+      "uniqueKey" : 2,
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 1
     }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
       "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
       "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_16",
     "chartMode" : "graph",
+    "chartType" : "column",
     "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
+      "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : true,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "# FD - RED",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      }, {
-        "max" : null,
-        "label" : "# segment - BLUE",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        },
-        "min" : 0
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 4,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.gauge.process.open_file_descriptors AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_4=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_4',metric='_SF_PLOT_KEY_##CHARTID##_1_4',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_4')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);A => find(query='(sf_metric:gauge.process.open_file_descriptors AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_16 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');B => find(query='(sf_metric:gauge.indices.segments.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_16 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 7,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);A => find(query='(sf_metric:gauge.process.open_file_descriptors AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');B => find(query='(sf_metric:gauge.indices.segments.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16')",
-  "marshallId" : 28,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_chart" : "Document Growth Rate %",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 20,
-    "allPlotConstructs" : [ ],
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Total",
-      "seriesData" : {
-        "metric" : "gauge.indices.docs.count"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Total",
-      "seriesData" : {
-        "metric" : "gauge.indices.docs.count"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Total",
-      "seriesData" : {
-        "metric" : "gauge.indices.docs.count"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 86400000
-          }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "Total",
-      "seriesData" : {
-        "metric" : "gauge.indices.docs.count"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 604800000
-          }
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "last hour",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "(A-B)*100/B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 6,
-      "name" : "last day",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "(A-C)*100/C",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 7,
-      "name" : "last week",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "(A-D)*100/D",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 8,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_20",
-    "chartMode" : "list",
-    "chartconfig" : {
       "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : false,
       "range" : -7200000,
-      "maxDecimalPlaces" : 4,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
+        "id" : "yAxis0",
+        "label" : "# FD - RED",
         "max" : null,
-        "label" : "",
+        "min" : 0,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "id" : "yAxis0"
+        }
       }, {
+        "label" : "# segment - BLUE",
         "max" : null,
-        "min" : null,
+        "min" : 0,
         "plotlines" : {
           "high" : null,
           "low" : null
@@ -5287,2494 +2137,5888 @@
         "title" : {
           "text" : ""
         }
-      } ],
-      "sortPreference" : "-value",
-      "absoluteEnd" : null
+      } ]
     },
+    "currentUniqueKey" : 4,
     "relatedDetectors" : [ ],
-    "currentUniqueKey" : 13,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.gauge.indices.docs.count AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_6_20=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK=[?A,?C,!OUT]{(?A - ?C) * 100 / ?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_20=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK=[?A,?D,!OUT]{(?A - ?D) * 100 / ?D->!OUT};A => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_20;B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-3600000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_20;C => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-86400000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_20;D => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-604800000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_20;_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_20->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_20->?B:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_20->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_20->?C:_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_20->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_20->?D:_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK",
-  "sf_cacheProgram" : true,
-  "sf_chartIndex" : 1,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 12000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_20=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_20=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_6_20=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK=[?A,?C,!OUT]{(?A - ?C) * 100 / ?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_20=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK=[?A,?D,!OUT]{(?A - ?D) * 100 / ?D->!OUT};A => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-3600000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');C => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-86400000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');D => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(offset=-604800000) -> split -> stats:!mean -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_20 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_20->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_20->?B:_SF_PLOT_KEY_##CHARTID##_5_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_20->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_20->?C:_SF_PLOT_KEY_##CHARTID##_6_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_20->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_20',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_20');_SF_PLOT_KEY_##CHARTID##_1_20->?A:_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_20->?D:_SF_PLOT_KEY_##CHARTID##_7_20_MACROBLOCK",
-  "marshallId" : 29,
-  "marshallMemberOf" : [ 18 ]
-}, {
-  "sf_uiModel" : {
+    "revisionNumber" : 16,
     "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_16"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);A => find(query='(sf_metric:gauge.process.open_file_descriptors AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');B => find(query='(sf_metric:gauge.indices.segments.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16')"
+}, {
+  "marshallId" : 13,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : true,
+  "sf_chart" : "Requests/sec",
+  "sf_chartIndex" : 1441143740915,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 12000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');B => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');C => find(query='(sf_metric:counter.indices.get.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
-    "revisionNumber" : 18,
     "allPlotConstructs" : [ ],
-    "chartType" : "area",
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.indices.store.size AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
     "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
-        "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
-        "property" : "host",
-        "type" : "property"
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
       } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Search",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-total"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 1,
-      "name" : "GC time",
-      "seriesData" : {
-        "metric" : "counter.jvm.gc.time"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Index",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
       }, {
-        "iconClass" : "icon-properties",
-        "value" : "integration-test-elasticsearch-1.7.1-2",
-        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
         "NOT" : false,
-        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "iconClass" : "icon-properties",
         "property" : "host",
-        "type" : "property"
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 2,
-      "name" : "counter.jvm.uptime",
       "seriesData" : {
-        "metric" : "counter.jvm.uptime"
+        "metric" : "counter.indices.indexing.index-total"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
       "type" : "plot",
+      "uniqueKey" : 2,
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "A - Timeshift 1h",
-      "valid" : true,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "metricDefinition" : { },
-      "type" : "ratio",
-      "expressionText" : "A",
-      "seriesData" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "B - Timeshift 1h",
-      "valid" : true,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "metricDefinition" : { },
-      "type" : "ratio",
-      "expressionText" : "B",
-      "seriesData" : { }
-    }, {
-      "metricDefinition" : { },
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "(A-E)*100/(B-F)",
-      "valid" : true,
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "configuration" : {
-        "colorOverride" : "#0077c2",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
+        "rollupPolicy" : null
       },
-      "type" : "ratio",
-      "expressionText" : "(A-C)*100/(B-D)",
-      "seriesData" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 6,
-      "name" : "New Plot",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
       "focusNext" : false,
+      "invisible" : false,
       "metricDefinition" : { },
+      "name" : "Get",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.get.total"
+      },
+      "transient" : false,
       "type" : "plot",
-      "seriesData" : { }
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_18",
-    "chartMode" : "graph",
+    "chartMode" : "list",
+    "chartType" : "line",
     "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
+      "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
       "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
+        "id" : "yAxis0",
         "max" : null,
-        "label" : "gc time %",
+        "min" : null,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
+        }
+      } ]
     },
+    "currentUniqueKey" : 5,
     "relatedDetectors" : [ ],
-    "currentUniqueKey" : 9,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.jvm.gc.time AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_7_18=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK=[?A,?E,?B,?F,!OUT]{(?A - ?E) * 100 / (?B - ?F)->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18;B => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18;find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5;_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6;_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6->?B:_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_18->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_18->?E:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_18->?F:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK",
-  "sf_description" : "last hour",
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "marshallId" : 30,
-  "marshallMemberOf" : [ 18 ],
-  "sf_chart" : "GC Time %",
-  "sf_cacheProgram" : true,
-  "sf_chartIndex" : 8,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 12000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK=[?A,!OUT]{?A->!OUT};_SF_PLOT_KEY_##CHARTID##_6_18=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK=[?B,!OUT]{?B->!OUT};_SF_PLOT_KEY_##CHARTID##_7_18=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK=[?A,?E,?B,?F,!OUT]{(?A - ?E) * 100 / (?B - ?F)->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');B => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5;_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18_TIMESHIFTFOR5->?A:_SF_PLOT_KEY_##CHARTID##_5_18_MACROBLOCK;find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6;_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_6_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_2_18_TIMESHIFTFOR6->?B:_SF_PLOT_KEY_##CHARTID##_6_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_7_18->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_18',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_18');_SF_PLOT_KEY_##CHARTID##_1_18->?A:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_18->?E:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_18->?B:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_18->?F:_SF_PLOT_KEY_##CHARTID##_7_18_MACROBLOCK"
-}, {
-  "sf_filterAlias" : {
-    "variables" : [ {
-      "dimension" : "plugin_instance",
-      "alias" : "cluster",
-      "globalScope" : true,
-      "required" : true,
-      "description" : "Elasticsearch cluster",
-      "restricted" : false,
-      "preferredSuggestions" : [ ]
-    } ]
-  },
-  "sf_dashboard" : "Elasticsearch Cluster",
-  "sf_uiModel" : {
-    "widgets" : [ {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1441323819642,
-        "id" : 1
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 4,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 3,
-        "id" : 2
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 4,
-      "sizeY" : 1,
-      "col" : 8,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1443736777214,
-        "id" : 3
-      },
-      "row" : 0
-    }, {
-      "sizeX" : 6,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 14,
-        "id" : 8
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 6,
-      "sizeY" : 1,
-      "col" : 6,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "New Text Block",
-        "chartIndex" : 5,
-        "id" : 9
-      },
-      "row" : 1
-    }, {
-      "sizeX" : 6,
-      "sizeY" : 1,
-      "col" : 6,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1443199023929,
-        "id" : 7
-      },
-      "row" : 2
-    }, {
-      "sizeX" : 6,
-      "sizeY" : 1,
-      "col" : 0,
-      "type" : "chart",
-      "options" : {
-        "type" : "chart",
-        "name" : "",
-        "chartIndex" : 1442525196684,
-        "id" : 10
-      },
-      "row" : 2
-    } ],
-    "version" : 1
-  },
-  "sf_discoverySelectors" : [ "_exists_:plugin_instance" ],
-  "sf_description" : "",
-  "sf_type" : "Dashboard",
-  "sf_discoveryQuery" : "plugin:elasticsearch",
-  "marshallId" : 31,
-  "marshallMemberOf" : [ 2 ]
-}, {
-  "sf_uiModel" : {
+    "revisionNumber" : 13,
     "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_13"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_13=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');B => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');C => find(query='(sf_metric:counter.indices.get.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')"
+}, {
+  "marshallId" : 14,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Cache Sizes (bytes)",
+  "sf_chartIndex" : 1440632194739,
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);A => find(query='(sf_metric:gauge.indices.cache.filter.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.indices.cache.field.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
-    "revisionNumber" : 21,
     "allPlotConstructs" : [ ],
-    "chartType" : "area",
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ],
     "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "filter cache size",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
         "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
         "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.cache.filter.size"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 1,
-      "name" : "Used (bytes)",
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "field cache size",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.cache.field.size"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "useKMG2" : true,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "size (bytes)",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 21,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_21"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);A => find(query='(sf_metric:gauge.indices.cache.filter.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.indices.cache.field.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')"
+}, {
+  "marshallId" : 15,
+  "marshallMemberOf" : [ 3 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Memory Heap Size (bytes)",
+  "sf_chartIndex" : 3,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "used",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
+      } ],
       "seriesData" : {
         "metric" : "gauge.jvm.mem.heap-used"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "committed",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
         "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
         "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
+        "iconClass" : "icon-properties",
+        "property" : "host",
+        "propertyValue" : "integration-test-elasticsearch-1.7.1-2",
+        "query" : "host:\"integration-test-elasticsearch-1.7.1-2\"",
+        "type" : "property",
+        "value" : "integration-test-elasticsearch-1.7.1-2"
       } ],
-      "uniqueKey" : 2,
-      "name" : "Used (bytes)",
       "seriesData" : {
         "metric" : "gauge.jvm.mem.heap-committed"
       },
       "sf_programText" : "",
-      "dataManipulations" : [ ],
       "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
       "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "A*100/G",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "expressionText" : "A*100/B",
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "min",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MIN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 5,
-      "name" : "p10",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 10
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0dba8f",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 6,
-      "name" : "p50",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 50
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#00b9ff",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 7,
-      "name" : "p90",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 90
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#f47e00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 8,
-      "name" : "max",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#bd468d",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 9,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_21",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : 110,
-        "label" : "% used",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      }, {
-        "max" : null,
-        "label" : "Used %",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        },
-        "min" : null
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 15,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_21=id(report=1);D => _SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_21=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_21=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_21=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_21=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21;B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21;_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK",
-  "sf_description" : "percentile distribution",
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "marshallId" : 32,
-  "marshallMemberOf" : [ 31 ],
-  "sf_chart" : "Heap %",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 3,
-  "sf_jobMaxDelay" : 0,
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_21=id(report=1);D => _SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_21=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_21=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_21=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_21=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK"
-}, {
-  "sf_chart" : "Deleted Documents %",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 19,
-    "allPlotConstructs" : [ ],
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "gauge.indices.total.docs.deleted - Mean by index",
-      "seriesData" : {
-        "metric" : "gauge.indices.total.docs.deleted"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "index"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
       "uniqueKey" : 2,
-      "name" : "gauge.indices.total.docs.count - Mean by index",
-      "seriesData" : {
-        "metric" : "gauge.indices.total.docs.count"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "index"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
       "valid" : false,
-      "metricDefinition" : { }
+      "yAxisIndex" : 0
     }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "% of Deleted Documents",
-      "seriesData" : { },
       "dataManipulations" : [ ],
-      "expressionText" : "A*100/B",
-      "transient" : false,
-      "yAxisIndex" : 0,
+      "focusNext" : false,
       "invisible" : false,
-      "focusNext" : false,
-      "type" : "ratio",
-      "valid" : true,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 4,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_19",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : false,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : 110,
-        "label" : "deleted %",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 5,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.total.docs.deleted AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19;B => find(query='(sf_metric:gauge.indices.total.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19;_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_19->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 14,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.total.docs.deleted AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');B => find(query='(sf_metric:gauge.indices.total.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_19->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK",
-  "marshallId" : 33,
-  "marshallMemberOf" : [ 31 ]
-}, {
-  "sf_chart" : "Thread Pool Rejections",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 9,
-    "allPlotConstructs" : [ ],
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Bulk",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.bulk.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Flush",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.flush.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Generic",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.generic.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "Get",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.get.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 5,
-      "name" : "Index",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.index.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 6,
-      "name" : "Merge",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.merge.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 7,
-      "name" : "Optimize",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.optimize.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 8,
-      "name" : "Refresh",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.refresh.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 9,
-      "name" : "Search",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.search.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 10,
-      "name" : "Snapshot",
-      "seriesData" : {
-        "metric" : "counter.thread_pool.snapshot.rejected"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "plugin_instance"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "SUM",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 11,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_9",
-    "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "rejections / sec",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 12,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.bulk.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_3',metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.flush.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_2_3',metric='_SF_PLOT_KEY_##CHARTID##_2_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.generic.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_3_3',metric='_SF_PLOT_KEY_##CHARTID##_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.get.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_4_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_4_3',metric='_SF_PLOT_KEY_##CHARTID##_4_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.index.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_5_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_5_3',metric='_SF_PLOT_KEY_##CHARTID##_5_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.merge.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_6_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_6_3',metric='_SF_PLOT_KEY_##CHARTID##_6_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.optimize.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_7_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_7_3',metric='_SF_PLOT_KEY_##CHARTID##_7_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.refresh.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_8_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_8_3',metric='_SF_PLOT_KEY_##CHARTID##_8_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.search.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_9_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_9_3',metric='_SF_PLOT_KEY_##CHARTID##_9_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.snapshot.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_10_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_10_3',metric='_SF_PLOT_KEY_##CHARTID##_10_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_9=id(report=1);A => find(query='(sf_metric:counter.thread_pool.bulk.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');B => find(query='(sf_metric:counter.thread_pool.flush.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');C => find(query='(sf_metric:counter.thread_pool.generic.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');D => find(query='(sf_metric:counter.thread_pool.get.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');E => find(query='(sf_metric:counter.thread_pool.index.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');F => find(query='(sf_metric:counter.thread_pool.merge.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_6_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');G => find(query='(sf_metric:counter.thread_pool.optimize.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_7_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');H => find(query='(sf_metric:counter.thread_pool.refresh.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');I => find(query='(sf_metric:counter.thread_pool.search.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');J => find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_9 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 5,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_9=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_9=id(report=1);A => find(query='(sf_metric:counter.thread_pool.bulk.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');B => find(query='(sf_metric:counter.thread_pool.flush.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');C => find(query='(sf_metric:counter.thread_pool.generic.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');D => find(query='(sf_metric:counter.thread_pool.get.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');E => find(query='(sf_metric:counter.thread_pool.index.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');F => find(query='(sf_metric:counter.thread_pool.merge.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_6_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');G => find(query='(sf_metric:counter.thread_pool.optimize.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_7_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');H => find(query='(sf_metric:counter.thread_pool.refresh.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');I => find(query='(sf_metric:counter.thread_pool.search.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9');J => find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_9 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_9',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_9')",
-  "marshallId" : 34,
-  "marshallMemberOf" : [ 31 ]
-}, {
-  "sf_chart" : "GC Time %",
-  "sf_uiModel" : {
-    "sf_detectorDecorators" : [ ],
-    "allDetectorDecorators" : [ ],
-    "revisionNumber" : 26,
-    "allPlotConstructs" : [ ],
-    "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "counter.jvm.gc.time"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "counter.jvm.uptime"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "counter.jvm.gc.time"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "Used (bytes)",
-      "seriesData" : {
-        "metric" : "counter.jvm.uptime"
-      },
-      "sf_programText" : "",
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "TIMESHIFT",
-          "options" : {
-            "milliseconds" : 3600000
-          }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : "MAX_ROLLUP"
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 5,
-      "name" : "min",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "(A-C)*100/(B-D)",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 6,
-      "name" : "min",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MIN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 7,
-      "name" : "p10",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 10
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0dba8f",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 8,
-      "name" : "p50",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 50
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#00b9ff",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 9,
-      "name" : "p90",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "PERCENTILE",
-          "options" : {
-            "percentile" : 90
-          }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#f47e00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 10,
-      "name" : "max",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#bd468d",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION"
-      },
-      "type" : "ratio",
-      "expressionText" : "E",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 11,
-      "name" : "New Plot",
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
       "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
       "type" : "plot",
-      "seriesData" : { }
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_26",
     "chartMode" : "graph",
-    "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "stackedChart" : false,
-      "colorByMetric" : true,
-      "range" : -7200000,
-      "maxDecimalPlaces" : 3,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : 0,
-        "max" : null,
-        "label" : "% gc time",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      }, {
-        "max" : null,
-        "label" : "Used %",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        },
-        "min" : null
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
-    },
-    "relatedDetectors" : [ ],
-    "currentUniqueKey" : 25,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ]
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_26=id(report=1);R => _SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK=[?A,?O,?G,?P,!OUT]{(?A - ?O) * 100 / (?G - ?P)->!OUT};_SF_PLOT_KEY_##CHARTID##_19_26=id(report=1);S => _SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_20_26=id(report=1);T => _SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_21_26=id(report=1);U => _SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_22_26=id(report=1);V => _SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_23_26=id(report=1);W => _SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26;G => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_26;O => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_15_26;P => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_16_26;_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_18_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_18_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_15_26->?O:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_26->?G:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_16_26->?P:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_19_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_19_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_20_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_20_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_21_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_21_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_22_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_22_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_23_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_23_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_description" : "percentile distribution over the last hour",
-  "sf_chartIndex" : 1443736777214,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_26=id(report=1);R => _SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK=[?A,?O,?G,?P,!OUT]{(?A - ?O) * 100 / (?G - ?P)->!OUT};_SF_PLOT_KEY_##CHARTID##_19_26=id(report=1);S => _SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_20_26=id(report=1);T => _SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_21_26=id(report=1);U => _SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_22_26=id(report=1);V => _SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_23_26=id(report=1);W => _SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');G => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');O => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_15_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_15_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');P => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_16_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_16_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_18_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_18_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_15_26->?O:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_26->?G:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_16_26->?P:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_19_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_19_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_20_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_20_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_21_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_21_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_22_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_22_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_23_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_23_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK",
-  "marshallId" : 35,
-  "marshallMemberOf" : [ 31 ]
-}, {
-  "sf_chart" : "Cluster Shard Allocation",
-  "sf_uiModel" : {
-    "revisionNumber" : 11,
     "chartType" : "area",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "Unassigned",
-      "seriesData" : {
-        "metric" : "gauge.cluster.unassigned-shards"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#b04600",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "Relocating",
-      "seriesData" : {
-        "metric" : "gauge.cluster.relocating-shards"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#0077c2",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 3,
-      "name" : "Primary",
-      "seriesData" : {
-        "metric" : "gauge.cluster.active-primary-shards"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#007c1d",
-        "rollupPolicy" : null,
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 4,
-      "name" : "Active",
-      "seriesData" : {
-        "metric" : "gauge.cluster.active-shards"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MEAN",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : true,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 5,
-      "name" : "Replica",
-      "seriesData" : { },
-      "transient" : false,
-      "dataManipulations" : [ ],
-      "valid" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "colorOverride" : "#05ce00",
-        "maxExtrapolations" : -1,
-        "extrapolationPolicy" : "AUTO"
-      },
-      "type" : "ratio",
-      "expressionText" : "D-C",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 6,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_11",
-    "chartMode" : "graph",
-    "relatedDetectors" : [ ],
     "chartconfig" : {
       "absoluteEnd" : null,
-      "rangeEnd" : 0,
       "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
       "range" : -7200000,
-      "updateInterval" : "",
-      "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
-        "min" : null,
-        "max" : null,
-        "label" : "# shards",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      } ],
+      "rangeEnd" : 0,
       "sortPreference" : "",
-      "forcedResolution" : "0"
-    },
-    "currentUniqueKey" : 9
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK=[?D,?C,!OUT]{?D - ?C->!OUT};A => find(query='(sf_metric:gauge.cluster.unassigned\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');B => find(query='(sf_metric:gauge.cluster.relocating\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');C => find(query='(sf_metric:gauge.cluster.active\\\\-primary\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');D => find(query='(sf_metric:gauge.cluster.active\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_11;_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_4_11->?D:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_11->?C:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1443199023929,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK=[?D,?C,!OUT]{?D - ?C->!OUT};A => find(query='(sf_metric:gauge.cluster.unassigned\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');B => find(query='(sf_metric:gauge.cluster.relocating\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');C => find(query='(sf_metric:gauge.cluster.active\\\\-primary\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');D => find(query='(sf_metric:gauge.cluster.active\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_4_11->?D:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_11->?C:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK",
-  "marshallId" : 36,
-  "marshallMemberOf" : [ 31 ]
-}, {
-  "sf_chart" : "# Nodes",
-  "sf_uiModel" : {
-    "revisionNumber" : 13,
-    "chartType" : "line",
-    "allPlots" : [ {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 1,
-      "name" : "total",
-      "seriesData" : {
-        "metric" : "gauge.cluster.number-of-nodes"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
-      "name" : "data nodes",
-      "seriesData" : {
-        "metric" : "gauge.cluster.number-of-data_nodes"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "type" : "aggregation",
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          }
-        },
-        "fn" : {
-          "type" : "MAX",
-          "options" : { }
-        },
-        "showMe" : false
-      } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
-      "focusNext" : false,
-      "type" : "plot",
-      "metricDefinition" : { }
-    } ],
-    "uiHelperValue" : "##CHARTID##_13",
-    "chartMode" : "list",
-    "relatedDetectors" : [ ],
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "rangeEnd" : 0,
-      "absoluteStart" : null,
-      "colorByMetric" : true,
-      "range" : -7200000,
+      "stackedChart" : false,
       "updateInterval" : "",
+      "useKMG2" : true,
       "yAxisConfigurations" : [ {
-        "max" : null,
-        "min" : null,
         "id" : "yAxis0",
+        "label" : "size (bytes)",
+        "max" : null,
+        "min" : 0,
         "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
         }
-      } ],
-      "sortPreference" : "-value"
+      } ]
     },
-    "currentUniqueKey" : 4
-  },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);A => find(query='(sf_metric:gauge.cluster.number\\\\-of\\\\-nodes AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');B => find(query='(sf_metric:gauge.cluster.number\\\\-of\\\\-data_nodes AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-  "sf_cacheProgram" : false,
-  "sf_chartIndex" : 1441323819642,
-  "sf_jobMaxDelay" : 0,
-  "sf_type" : "Chart",
-  "sf_jobResolution" : 10000,
-  "sf_throttledProgramText" : "",
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);A => find(query='(sf_metric:gauge.cluster.number\\\\-of\\\\-nodes AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');B => find(query='(sf_metric:gauge.cluster.number\\\\-of\\\\-data_nodes AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
-  "marshallId" : 37,
-  "marshallMemberOf" : [ 31 ]
-}, {
-  "sf_uiModel" : {
+    "currentUniqueKey" : 7,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 21,
     "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_21"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (host:integration\\\\-test\\\\-elasticsearch\\\\-1.7.1\\\\-2))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21')"
+}, {
+  "marshallId" : 16,
+  "marshallMemberOf" : [ 2 ],
+  "sf_dashboard" : "Elasticsearch Cluster",
+  "sf_description" : "",
+  "sf_discoveryQuery" : "plugin:elasticsearch",
+  "sf_discoverySelectors" : [ "_exists_:plugin_instance" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "alias" : "cluster",
+      "description" : "Elasticsearch cluster",
+      "dimension" : "plugin_instance",
+      "globalScope" : true,
+      "preferredSuggestions" : [ ],
+      "required" : true,
+      "restricted" : false
+    } ]
+  },
+  "sf_type" : "Dashboard",
+  "sf_uiModel" : {
+    "version" : 1,
+    "widgets" : [ {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441323819642,
+        "id" : 1,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 3,
+        "id" : 2,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1443736777214,
+        "id" : 3,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 14,
+        "id" : 4,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 5,
+        "id" : 5,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1443199023929,
+        "id" : 6,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1442525196684,
+        "id" : 7,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 6,
+      "sizeY" : 1,
+      "type" : "chart"
+    } ]
+  }
+}, {
+  "marshallId" : 17,
+  "marshallMemberOf" : [ 16 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Heap %",
+  "sf_chartIndex" : 3,
+  "sf_description" : "percentile distribution",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_21=id(report=1);D => _SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_21=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_21=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_21=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_21=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21;B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21;_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
     "allDetectorDecorators" : [ ],
-    "revisionNumber" : 24,
     "allPlotConstructs" : [ ],
-    "chartType" : "area",
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
     "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
         "NOT" : false,
-        "query" : "plugin:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
         "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
         "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
+        "iconClass" : "icon-properties",
         "property" : "plugin_instance",
-        "type" : "property"
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
       } ],
+      "seriesData" : {
+        "metric" : "gauge.jvm.mem.heap-used"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.jvm.mem.heap-committed"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "A*100/B",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "A*100/G",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0dba8f",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 10
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p10",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p50",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 90
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p90",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 7,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 8,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 9,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "% used",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "Used %",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 15,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 21,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_21"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_21=id(report=1);D => _SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_21=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_21=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_21=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_21=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK=[?C,!OUT]{?C->!OUT};A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_4_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_5_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_6_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_7_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21->?C:_SF_PLOT_KEY_##CHARTID##_8_21_MACROBLOCK"
+}, {
+  "marshallId" : 18,
+  "marshallMemberOf" : [ 16 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Cache Size (bytes)",
+  "sf_chartIndex" : 1442525196684,
+  "sf_description" : "",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);A => find(query='(sf_metric:gauge.indices.total.filter\\\\-cache.memory\\\\-size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');B => find(query='(sf_metric:gauge.indices.total.fielddata.memory\\\\-size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "index"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "Filter Cache",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
       "seriesData" : {
         "metric" : "gauge.indices.total.filter-cache.memory-size"
       },
       "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
       "dataManipulations" : [ {
         "direction" : {
-          "type" : "aggregation",
           "options" : {
             "aggregateGroupBy" : [ {
               "value" : "index"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
-          }
+          },
+          "type" : "aggregation"
         },
         "fn" : {
-          "type" : "MEAN",
-          "options" : { }
+          "options" : { },
+          "type" : "MEAN"
         },
         "showMe" : false
       } ],
-      "transient" : false,
-      "yAxisIndex" : 0,
-      "invisible" : false,
       "focusNext" : false,
-      "configuration" : {
-        "rollupPolicy" : null
-      },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin:elasticsearch",
-        "property" : "plugin",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "plugin_instance:elasticsearch",
-        "propertyValue" : "elasticsearch",
-        "NOT" : false,
-        "query" : "plugin_instance:elasticsearch",
-        "property" : "plugin_instance",
-        "type" : "property"
-      } ],
-      "uniqueKey" : 2,
+      "invisible" : false,
+      "metricDefinition" : { },
       "name" : "Field Cache",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
       "seriesData" : {
         "metric" : "gauge.indices.total.fielddata.memory-size"
       },
       "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 1
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "size (bytes)",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 24,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_24"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);A => find(query='(sf_metric:gauge.indices.total.filter\\\\-cache.memory\\\\-size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');B => find(query='(sf_metric:gauge.indices.total.fielddata.memory\\\\-size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24')"
+}, {
+  "marshallId" : 19,
+  "marshallMemberOf" : [ 16 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Cluster Shard Allocation",
+  "sf_chartIndex" : 1443199023929,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK=[?D,?C,!OUT]{?D - ?C->!OUT};A => find(query='(sf_metric:gauge.cluster.unassigned\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');B => find(query='(sf_metric:gauge.cluster.relocating\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');C => find(query='(sf_metric:gauge.cluster.active\\\\-primary\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');D => find(query='(sf_metric:gauge.cluster.active\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_11;_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_11->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_4_11->?D:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_11->?C:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
       "dataManipulations" : [ {
         "direction" : {
-          "type" : "aggregation",
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Unassigned",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.cluster.unassigned-shards"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Relocating",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.cluster.relocating-shards"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Primary",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.cluster.active-primary-shards"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Active",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.cluster.active-shards"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "D-C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Replica",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 6,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "# shards",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 9,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11,
+    "uiHelperValue" : "##CHARTID##_11"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK=[?D,?C,!OUT]{?D - ?C->!OUT};A => find(query='(sf_metric:gauge.cluster.unassigned\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');B => find(query='(sf_metric:gauge.cluster.relocating\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');C => find(query='(sf_metric:gauge.cluster.active\\\\-primary\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');D => find(query='(sf_metric:gauge.cluster.active\\\\-shards AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_11->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');_SF_PLOT_KEY_##CHARTID##_4_11->?D:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_11->?C:_SF_PLOT_KEY_##CHARTID##_5_11_MACROBLOCK"
+}, {
+  "marshallId" : 20,
+  "marshallMemberOf" : [ 16 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Thread Pool Rejections",
+  "sf_chartIndex" : 5,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_10=id(report=1);find(query='(sf_metric:counter.thread_pool.bulk.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.flush.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.generic.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.get.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.index.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.merge.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_6_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.optimize.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_7_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.refresh.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.search.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.rejected AND _missing_:sf_programId)') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance','thread_pool') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_11_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_11_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.bulk.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_3',metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.flush.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_2_3',metric='_SF_PLOT_KEY_##CHARTID##_2_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.generic.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_3_3',metric='_SF_PLOT_KEY_##CHARTID##_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.get.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_4_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_4_3',metric='_SF_PLOT_KEY_##CHARTID##_4_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.index.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_5_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_5_3',metric='_SF_PLOT_KEY_##CHARTID##_5_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.merge.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_6_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_6_3',metric='_SF_PLOT_KEY_##CHARTID##_6_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.optimize.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_7_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_7_3',metric='_SF_PLOT_KEY_##CHARTID##_7_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.refresh.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_8_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_8_3',metric='_SF_PLOT_KEY_##CHARTID##_8_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.search.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_9_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_9_3',metric='_SF_PLOT_KEY_##CHARTID##_9_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.snapshot.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_10_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_10_3',metric='_SF_PLOT_KEY_##CHARTID##_10_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#999999",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Bulk rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.bulk.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Flush rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.flush.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Generic rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.generic.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#6ca2b7",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Get rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.get.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Index rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.index.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Merge rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.merge.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 6,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e5b312",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Optimize rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.optimize.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Refresh rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.refresh.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 8,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Search rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.search.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 9,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#a747ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Snapshot rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.snapshot.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            }, {
+              "value" : "thread_pool"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "rejections by thread pool",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.rejected",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 12,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "rejections / sec",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 13,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 10,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_10"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_10=id(report=1);find(query='(sf_metric:counter.thread_pool.bulk.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.flush.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.generic.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.get.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.index.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.merge.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_6_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.optimize.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_7_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.refresh.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.search.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');find(query='(sf_metric:counter.thread_pool.rejected AND _missing_:sf_programId)') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance','thread_pool') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_11_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_11_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')"
+}, {
+  "marshallId" : 21,
+  "marshallMemberOf" : [ 16 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "GC Time %",
+  "sf_chartIndex" : 1443736777214,
+  "sf_description" : "percentile distribution over the last hour",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_26=id(report=1);R => _SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK=[?A,?O,?G,?P,!OUT]{(?A - ?O) * 100 / (?G - ?P)->!OUT};_SF_PLOT_KEY_##CHARTID##_19_26=id(report=1);S => _SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_20_26=id(report=1);T => _SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_21_26=id(report=1);U => _SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_22_26=id(report=1);V => _SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_23_26=id(report=1);W => _SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26;G => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_26;O => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_15_26;P => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_16_26;_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_18_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_18_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_15_26->?O:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_26->?G:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_16_26->?P:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_19_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_19_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_20_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_20_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_21_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_21_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_22_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_22_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_23_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_23_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.gc.time"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.uptime"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.gc.time"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.uptime"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "(A-C)*100/(B-D)",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0dba8f",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 10
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p10",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 7,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p50",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 8,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 90
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p90",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 9,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 10,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "% gc time",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "Used %",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 25,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 26,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_26"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_26=id(report=1);R => _SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK=[?A,?O,?G,?P,!OUT]{(?A - ?O) * 100 / (?G - ?P)->!OUT};_SF_PLOT_KEY_##CHARTID##_19_26=id(report=1);S => _SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_20_26=id(report=1);T => _SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_21_26=id(report=1);U => _SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_22_26=id(report=1);V => _SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_23_26=id(report=1);W => _SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK=[?R,!OUT]{?R->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');G => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');O => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_15_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_15_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');P => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_16_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_16_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_18_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_18_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_15_26->?O:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_26->?G:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_16_26->?P:_SF_PLOT_KEY_##CHARTID##_18_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_19_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_19_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_19_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_20_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_20_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_20_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_21_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_21_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_21_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_22_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_22_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_22_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_23_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_23_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_18_26->?R:_SF_PLOT_KEY_##CHARTID##_23_26_MACROBLOCK"
+}, {
+  "marshallId" : 22,
+  "marshallMemberOf" : [ 16 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Deleted Documents %",
+  "sf_chartIndex" : 14,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.total.docs.deleted AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19;B => find(query='(sf_metric:gauge.indices.total.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19;_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_19->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
               "value" : "index"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
-          }
+          },
+          "type" : "aggregation"
         },
         "fn" : {
-          "type" : "MEAN",
-          "options" : { }
+          "options" : { },
+          "type" : "MEAN"
         },
         "showMe" : false
       } ],
-      "transient" : false,
-      "yAxisIndex" : 1,
-      "invisible" : false,
       "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "gauge.indices.total.docs.deleted - Mean by index",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.total.docs.deleted"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
       "configuration" : {
         "rollupPolicy" : null
       },
-      "type" : "plot",
-      "valid" : false,
-      "metricDefinition" : { }
-    }, {
-      "queryItems" : [ ],
-      "uniqueKey" : 3,
-      "name" : "New Plot",
-      "seriesData" : { },
-      "dataManipulations" : [ ],
-      "transient" : true,
-      "yAxisIndex" : 0,
-      "invisible" : false,
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "index"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MEAN"
+        },
+        "showMe" : false
+      } ],
       "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "gauge.indices.total.docs.count - Mean by index",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.total.docs.count"
+      },
+      "sf_programText" : "",
+      "transient" : false,
       "type" : "plot",
-      "metricDefinition" : { }
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "A*100/B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "% of Deleted Documents",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "plugin_instance:elasticsearch"
+      } ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
     } ],
-    "uiHelperValue" : "##CHARTID##_24",
     "chartMode" : "graph",
+    "chartType" : "line",
     "chartconfig" : {
-      "forcedResolution" : "0",
-      "rangeEnd" : 0,
+      "absoluteEnd" : null,
       "absoluteStart" : null,
-      "stackedChart" : true,
-      "colorByMetric" : true,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
       "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
       "updateInterval" : "",
       "yAxisConfigurations" : [ {
-        "name" : "yAxis0",
+        "id" : "yAxis0",
+        "label" : "deleted %",
+        "max" : 110,
         "min" : 0,
-        "max" : null,
-        "label" : "size (bytes)",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "id" : "yAxis0"
-      }, {
-        "max" : null,
-        "title" : {
-          "text" : ""
-        },
-        "min" : null,
+        "name" : "yAxis0",
         "plotlines" : {
           "high" : null,
           "low" : null
         }
-      } ],
-      "sortPreference" : "",
-      "absoluteEnd" : null
+      } ]
     },
+    "currentUniqueKey" : 5,
     "relatedDetectors" : [ ],
-    "currentUniqueKey" : 4,
-    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ]
+    "revisionNumber" : 19,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_19"
   },
-  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);A => find(query='(sf_metric:gauge.indices.total.filter\\\\-cache.memory\\\\-size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');B => find(query='(sf_metric:gauge.indices.total.fielddata.memory\\\\-size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24')",
-  "sf_description" : "",
-  "sf_type" : "Chart",
-  "sf_throttledProgramText" : "",
-  "marshallId" : 38,
-  "marshallMemberOf" : [ 31 ],
-  "sf_chart" : "Cache Size (bytes)",
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_19=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_19=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.total.docs.deleted AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');B => find(query='(sf_metric:gauge.indices.total.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_19 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_19->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_19',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_19');_SF_PLOT_KEY_##CHARTID##_1_19->?A:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_19->?B:_SF_PLOT_KEY_##CHARTID##_3_19_MACROBLOCK"
+}, {
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 16 ],
   "sf_cacheProgram" : false,
+  "sf_chart" : "# Nodes",
+  "sf_chartIndex" : 1441323819642,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);A => find(query='(sf_metric:gauge.cluster.number\\\\-of\\\\-nodes AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');B => find(query='(sf_metric:gauge.cluster.number\\\\-of\\\\-data_nodes AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_13 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "total",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.cluster.number-of-nodes"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "data nodes",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin_instance",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin_instance:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.cluster.number-of-data_nodes"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 13,
+    "uiHelperValue" : "##CHARTID##_13"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_13=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_13=id(report=1);A => find(query='(sf_metric:gauge.cluster.number\\\\-of\\\\-nodes AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13');B => find(query='(sf_metric:gauge.cluster.number\\\\-of\\\\-data_nodes AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby() -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_13 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_13',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_13')"
+}, {
+  "marshallId" : 24,
+  "marshallMemberOf" : [ 2 ],
+  "sf_dashboard" : "Elasticsearch",
+  "sf_description" : "",
+  "sf_discoveryQuery" : "plugin:elasticsearch",
+  "sf_discoverySelectors" : [ "sf_hostHasService:elasticsearch", "plugin:elasticsearch" ],
+  "sf_type" : "Dashboard",
+  "sf_uiModel" : {
+    "version" : 1,
+    "widgets" : [ {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441323819642,
+        "id" : 1,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 3,
+        "id" : 2,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1443043692867,
+        "id" : 3,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 0,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441150718637,
+        "id" : 4,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 1443032267071,
+        "id" : 5,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 2,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 4,
+        "id" : 6,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 1,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1441215631067,
+        "id" : 7,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 2,
+        "id" : 8,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 2,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1,
+        "id" : 9,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1442525326269,
+        "id" : 10,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 16,
+        "id" : 11,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 3,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 14,
+        "id" : 12,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 4,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 4,
+      "options" : {
+        "chartIndex" : 1442525196684,
+        "id" : 13,
+        "name" : "",
+        "type" : "chart"
+      },
+      "row" : 4,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    }, {
+      "col" : 8,
+      "options" : {
+        "chartIndex" : 5,
+        "id" : 14,
+        "name" : "New Text Block",
+        "type" : "chart"
+      },
+      "row" : 4,
+      "sizeX" : 4,
+      "sizeY" : 1,
+      "type" : "chart"
+    } ]
+  }
+}, {
+  "marshallId" : 25,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "# Hosts/Clusters",
+  "sf_chartIndex" : 1441323819642,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_2_10 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "COUNT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "# hosts",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.indexing.index-total"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "COUNT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "# clusters",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.indexing.index-total"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 10,
+    "uiHelperValue" : "##CHARTID##_10"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_10=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_10=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_1_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10');B => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> groupby() -> stats:!count -> _SF_PLOT_KEY_##CHARTID##_2_10 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_10',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_10')"
+}, {
+  "marshallId" : 26,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Thread Pool Rejections",
+  "sf_chartIndex" : 5,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_11=id(report=1);find(query='(sf_metric:counter.thread_pool.bulk.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.flush.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_11;find(query='(sf_metric:counter.thread_pool.generic.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.get.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.index.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.merge.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_6_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.optimize.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_7_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.refresh.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.search.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance','thread_pool') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_11_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_11_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.bulk.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_3',metric='_SF_PLOT_KEY_##CHARTID##_1_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.flush.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_2_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_2_3',metric='_SF_PLOT_KEY_##CHARTID##_2_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.generic.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_3_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_3_3',metric='_SF_PLOT_KEY_##CHARTID##_3_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.get.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_4_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_4_3',metric='_SF_PLOT_KEY_##CHARTID##_4_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.index.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_5_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_5_3',metric='_SF_PLOT_KEY_##CHARTID##_5_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.merge.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_6_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_6_3',metric='_SF_PLOT_KEY_##CHARTID##_6_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.optimize.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_7_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_7_3',metric='_SF_PLOT_KEY_##CHARTID##_7_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.refresh.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_8_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_8_3',metric='_SF_PLOT_KEY_##CHARTID##_8_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.search.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_9_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_9_3',metric='_SF_PLOT_KEY_##CHARTID##_9_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')", "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.thread_pool.snapshot.rejected AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_10_3=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_10_3',metric='_SF_PLOT_KEY_##CHARTID##_10_3',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_3')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#999999",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Bulk rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.bulk.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Flush rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.flush.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Generic rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.generic.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#6ca2b7",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Get rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.get.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Index rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.index.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Merge rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.merge.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 6,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e5b312",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Optimize rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.optimize.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Refresh rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.refresh.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 8,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Search rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.search.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 9,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#876ff3",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Snapshot rejections",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.snapshot.rejected"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            }, {
+              "value" : "thread_pool"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "rejections by thread pool",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "dimension",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.thread_pool.rejected",
+        "regExStyle" : null
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 12,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "rejections / sec",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 13,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_11"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_8_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_9_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_10_11=id(report=1);_SF_PLOT_KEY_##CHARTID##_11_11=id(report=1);find(query='(sf_metric:counter.thread_pool.bulk.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.flush.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.generic.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_3_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.get.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_4_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.index.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_5_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_5_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.merge.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_6_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_6_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.optimize.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_7_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.refresh.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_8_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_8_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.search.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_9_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_9_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.snapshot.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_10_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_10_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11');find(query='(sf_metric:counter.thread_pool.rejected AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1) -> groupby('plugin_instance','thread_pool') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_11_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_11_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')"
+}, {
+  "marshallId" : 27,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Search Requests",
+  "sf_chartIndex" : 4,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.search.query-total AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "counter.indices.search.query-total - Sum by plugin_instance",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-total"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "requests / sec",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_11"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_11=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_11 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_11',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_11')"
+}, {
+  "marshallId" : 28,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Top Clusters by Query Latency (ms)",
+  "sf_chartIndex" : 1443032267071,
+  "sf_description" : "p99 latency over the last hour",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK=[?B,?D,?A,?C,!OUT]{(?B - ?D) / (?A - ?C)->!OUT};_SF_PLOT_KEY_##CHARTID##_6_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK=[?E,!OUT]{?E->!OUT};find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_26;find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_26;find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_26;_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_2_26->?B:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_26->?D:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_26->?C:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK:!OUT->groupby('plugin_instance')->stats:!p99->groupby()->groupby()->select(count=5):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_6_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_5_26->?E:_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.indices.search.query-total",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-total"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.indices.search.query-time",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-time"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.indices.search.query-total - Timeshift 1h",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-total"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.indices.search.query-time - Timeshift 1h",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-time"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "(B-D)/(A-C)",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "(B-D)/(A-C)",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 99
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 5
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 7,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "-value",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "Time (ms)",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 14,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 26,
+    "uiHelperValue" : "##CHARTID##_26"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_4_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK=[?B,?D,?A,?C,!OUT]{(?B - ?D) / (?A - ?C)->!OUT};_SF_PLOT_KEY_##CHARTID##_6_26=id(report=1);_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK=[?E,!OUT]{?E->!OUT};find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:counter.indices.search.query\\\\-total AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_3_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_3_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');find(query='(sf_metric:counter.indices.search.query\\\\-time AND _missing_:sf_programId) AND ((plugin:elasticsearch))') -> fetch(extrapolation='NULL_EXTRAPOLATION',maxExtrapolations=-1,rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_4_26 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_4_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_5_26->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_2_26->?B:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_26->?D:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_1_26->?A:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_3_26->?C:_SF_PLOT_KEY_##CHARTID##_5_26_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK:!OUT->groupby('plugin_instance')->stats:!p99->groupby()->groupby()->select(count=5):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_6_26->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_26',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_26');_SF_PLOT_KEY_##CHARTID##_5_26->?E:_SF_PLOT_KEY_##CHARTID##_6_26_MACROBLOCK"
+}, {
+  "marshallId" : 29,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Top Clusters by Search Requests",
+  "sf_chartIndex" : 1441150718637,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=3):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 3
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.search.query-total"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 12,
+    "uiHelperValue" : "##CHARTID##_12"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.search.query\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=3):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')"
+}, {
+  "marshallId" : 30,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Top Clusters by Indexing Requests",
+  "sf_chartIndex" : 1441215631067,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=3):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : "#876ff3",
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 3
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.indexing.index-total"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "maxDecimalPlaces" : 2,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 12,
+    "uiHelperValue" : "##CHARTID##_12"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> groupby() -> groupby() -> select(count=3):!top -> split() -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')"
+}, {
+  "marshallId" : 31,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Indexing Requests",
+  "sf_chartIndex" : 2,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.indexing.index-total AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "counter.indices.indexing.index-total - Sum by plugin_instance",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.indexing.index-total"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "sf_programText" : "",
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "requests / sec",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 12,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_12"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.indexing.index\\\\-total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')"
+}, {
+  "marshallId" : 32,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Merges/sec",
+  "sf_chartIndex" : 1442525326269,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.merges.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "configuration" : {
+        "colorOverride" : null,
+        "extrapolationPolicy" : "AUTO",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null,
+        "visualization" : "area"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "counter.indices.merges.total - Sum by plugin_instance",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.indices.merges.total"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "merges / sec",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 12,
+    "uiHelperValue" : "##CHARTID##_12"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_12=id(report=1);A => find(query='(sf_metric:counter.indices.merges.total AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(maxExtrapolations=-1) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_12 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_12',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_12')"
+}, {
+  "marshallId" : 33,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Heap %",
+  "sf_chartIndex" : 3,
+  "sf_description" : "percentile distribution",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_23=id(report=1);D => _SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_23=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_23=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_23=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_23=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_23;B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_23;_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_1_23->?A:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_23->?B:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_23->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.jvm.mem.heap-used"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.jvm.mem.heap-committed"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "A*100/B",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "A*100/G",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 4,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0dba8f",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 10
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p10",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p50",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 90
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p90",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 7,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 8,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 9,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "% used",
+        "max" : 110,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "Used %",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 15,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 23,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_23"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_23=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_23=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};_SF_PLOT_KEY_##CHARTID##_4_23=id(report=1);D => _SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_5_23=id(report=1);E => _SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_6_23=id(report=1);F => _SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_7_23=id(report=1);G => _SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};_SF_PLOT_KEY_##CHARTID##_8_23=id(report=1);H => _SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK=[?C,!OUT]{?C->!OUT};A => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-used AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_23 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');B => find(query='(sf_metric:gauge.jvm.mem.heap\\\\-committed AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_23 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_1_23->?A:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_23->?B:_SF_PLOT_KEY_##CHARTID##_3_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_4_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_4_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_4_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_5_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_5_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_5_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_6_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_6_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_6_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_7_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_7_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_7_23_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_8_23->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_8_23',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_23');_SF_PLOT_KEY_##CHARTID##_3_23->?C:_SF_PLOT_KEY_##CHARTID##_8_23_MACROBLOCK"
+}, {
+  "marshallId" : 34,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Document Growth %",
+  "sf_chartIndex" : 1,
+  "sf_description" : "last hour",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_17;B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(offset=-3600000) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_17;_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_17->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_1_17->?A:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_17->?B:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.gauge.indices.docs.count AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "gauge.indices.docs.count - Sum by plugin_instance",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.docs.count"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "gauge.indices.docs.count - Sum by plugin_instance - Timeshift 1h",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.docs.count"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "(A-B)*100/B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Growth rate",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "growth %",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 17,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_17"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_17=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_17=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(offset=-3600000) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_17 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_17->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_17',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_17');_SF_PLOT_KEY_##CHARTID##_1_17->?A:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_17->?B:_SF_PLOT_KEY_##CHARTID##_3_17_MACROBLOCK"
+}, {
+  "marshallId" : 35,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Cache Size (bytes)",
   "sf_chartIndex" : 1442525196684,
   "sf_jobMaxDelay" : 0,
   "sf_jobResolution" : 1000,
-  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_24=id(report=1);A => find(query='(sf_metric:gauge.indices.total.filter\\\\-cache.memory\\\\-size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');B => find(query='(sf_metric:gauge.indices.total.fielddata.memory\\\\-size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch) AND (plugin_instance:elasticsearch))') -> fetch -> groupby('index') -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_2_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24')"
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_22=id(report=1);A => find(query='(sf_metric:gauge.indices.cache.filter.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_22 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');B => find(query='(sf_metric:gauge.indices.cache.field.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_22 -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22')",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Filter Cache",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.cache.filter.size"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "Field Cache",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.cache.field.size"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "useKMG2" : true,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "size (bytes)",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 22,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_22"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_22=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_22=id(report=1);A => find(query='(sf_metric:gauge.indices.cache.filter.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_22 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22');B => find(query='(sf_metric:gauge.indices.cache.field.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_22 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_22',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_22')"
+}, {
+  "marshallId" : 36,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Top Clusters by Index Growth %",
+  "sf_chartIndex" : 16,
+  "sf_description" : "last day",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 10000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.store.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_16;B => find(query='(sf_metric:gauge.indices.store.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(offset=-86400000) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_16;_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK:!OUT->groupby()->groupby()->select(count=3):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_16->?B:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.indices.store.size AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "gauge.indices.store.size - Sum by plugin_instance",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.store.size"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "gauge.indices.store.size - Sum by plugin_instance - Timeshift 1d",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.indices.store.size"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 3
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "(A-B)*100/B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "Size (bytes)",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 16,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_16"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_16=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_16=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK=[?A,?B,!OUT]{(?A - ?B) * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.store.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');B => find(query='(sf_metric:gauge.indices.store.size AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(offset=-86400000) -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_16 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK:!OUT->groupby()->groupby()->select(count=3):!top->split() -> stats:!mean->_SF_PLOT_KEY_##CHARTID##_3_16->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_16',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_16');_SF_PLOT_KEY_##CHARTID##_1_16->?A:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_16->?B:_SF_PLOT_KEY_##CHARTID##_3_16_MACROBLOCK"
+}, {
+  "marshallId" : 37,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "GC Time %",
+  "sf_chartIndex" : 1443043692867,
+  "sf_description" : "percentile distribution over the last hour",
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_24=id(report=1);R => _SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK=[?A,?O,?G,?P,!OUT]{(?A - ?O) * 100 / (?G - ?P)->!OUT};_SF_PLOT_KEY_##CHARTID##_19_24=id(report=1);S => _SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_20_24=id(report=1);T => _SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_21_24=id(report=1);U => _SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_22_24=id(report=1);V => _SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_23_24=id(report=1);W => _SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24;G => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_24;O => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_15_24;P => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_16_24;_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_18_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_18_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_15_24->?O:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24->?G:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_16_24->?P:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_19_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_19_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_20_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_20_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_21_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_21_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_22_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_22_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_23_24->publish(metric='_SF_PLOT_KEY_##CHARTID##_23_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.bytes.jvm.mem.heap-used AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_2=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_2',metric='_SF_PLOT_KEY_##CHARTID##_1_2',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_2')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.gc.time"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.uptime"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.gc.time"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : "MAX_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "Used (bytes)",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "elasticsearch",
+        "query" : "plugin:elasticsearch",
+        "type" : "property",
+        "value" : "elasticsearch"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.jvm.uptime"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "(A-C)*100/(B-D)",
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#05ce00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MIN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "min",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 6,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#0dba8f",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 10
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p10",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 7,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 50
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p50",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 8,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#f47e00",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "percentile" : 90
+          },
+          "type" : "PERCENTILE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "p90",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 9,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "colorOverride" : "#bd468d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "MAX"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "max",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 10,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : true,
+      "forcedResolution" : "0",
+      "maxDecimalPlaces" : 3,
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "% gc time",
+        "max" : null,
+        "min" : 0,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "Used %",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 25,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 24,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_24"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_7_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_15_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_16_24=id(report=1);_SF_PLOT_KEY_##CHARTID##_18_24=id(report=1);R => _SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK=[?A,?O,?G,?P,!OUT]{(?A - ?O) * 100 / (?G - ?P)->!OUT};_SF_PLOT_KEY_##CHARTID##_19_24=id(report=1);S => _SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_20_24=id(report=1);T => _SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_21_24=id(report=1);U => _SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_22_24=id(report=1);V => _SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};_SF_PLOT_KEY_##CHARTID##_23_24=id(report=1);W => _SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK=[?R,!OUT]{?R->!OUT};A => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_1_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');G => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP') -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_7_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_7_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');O => find(query='(sf_metric:counter.jvm.gc.time AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_15_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_15_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');P => find(query='(sf_metric:counter.jvm.uptime AND NOT sf_metric:_SF_PLOT_KEY_*) AND ((plugin:elasticsearch))') -> fetch(rollup='MAX_ROLLUP',offset=-3600000) -> split -> stats:!mean -> _SF_PLOT_KEY_##CHARTID##_16_24 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_16_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_18_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_18_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_1_24->?A:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_15_24->?O:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_7_24->?G:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_16_24->?P:_SF_PLOT_KEY_##CHARTID##_18_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK:!OUT->groupby()->stats:!min->_SF_PLOT_KEY_##CHARTID##_19_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_19_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_19_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK:!OUT->groupby()->stats:!p10->_SF_PLOT_KEY_##CHARTID##_20_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_20_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_20_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK:!OUT->groupby()->stats:!p50->_SF_PLOT_KEY_##CHARTID##_21_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_21_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_21_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK:!OUT->groupby()->stats:!p90->_SF_PLOT_KEY_##CHARTID##_22_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_22_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_22_24_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK:!OUT->groupby()->stats:!max->_SF_PLOT_KEY_##CHARTID##_23_24->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_23_24',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_24');_SF_PLOT_KEY_##CHARTID##_18_24->?R:_SF_PLOT_KEY_##CHARTID##_23_24_MACROBLOCK"
+}, {
+  "marshallId" : 38,
+  "marshallMemberOf" : [ 24 ],
+  "sf_cacheProgram" : false,
+  "sf_chart" : "Deleted Documents %",
+  "sf_chartIndex" : 14,
+  "sf_jobMaxDelay" : 0,
+  "sf_jobResolution" : 1000,
+  "sf_programTextRegex" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.docs.deleted AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_21;B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_21;_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_21->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK",
+  "sf_throttledProgramText" : "",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allDetectorDecorators" : [ ],
+    "allPlotConstructs" : [ ],
+    "allPlotProgramText" : [ "find(refresh=300000,query='sf_metric:collectd.elasticsearch.*.counter.indices.docs.deleted AND sf_organizationID:##ORGID## AND NOT sf_metric:_*') -> fetch -> groupby('sf_source') -> stats:!max -> _SF_PLOT_KEY_##CHARTID##_1_7=id -> publish(defaultSource='_SF_PLOT_KEY_##CHARTID##_1_7',metric='_SF_PLOT_KEY_##CHARTID##_1_7',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_7')" ],
+    "allPlots" : [ {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "gauge.indices.docs.deleted - Sum by plugin_instance",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "gauge.indices.docs.deleted"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "plugin_instance"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "focusNext" : false,
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "gauge.indices.docs.count - Sum by plugin_instance",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : "gauge.indices.docs.count"
+      },
+      "sf_programText" : "",
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "valid" : false,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "expressionText" : "A*100/B",
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "% of Deleted Documents",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "dataManipulations" : [ ],
+      "focusNext" : false,
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "disableThrottle" : false,
+      "forcedResolution" : "0",
+      "range" : -7200000,
+      "rangeEnd" : 0,
+      "sortPreference" : "",
+      "stackedChart" : false,
+      "updateInterval" : "",
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "deleted %",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 21,
+    "sf_detectorDecorators" : [ ],
+    "uiHelperValue" : "##CHARTID##_21"
+  },
+  "sf_viewProgramText" : "_SF_PLOT_KEY_##CHARTID##_1_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_2_21=id(report=1);_SF_PLOT_KEY_##CHARTID##_3_21=id(report=1);C => _SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK=[?A,?B,!OUT]{?A * 100 / ?B->!OUT};A => find(query='(sf_metric:gauge.indices.docs.deleted AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_1_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_1_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');B => find(query='(sf_metric:gauge.indices.docs.count AND NOT sf_metric:_SF_PLOT_KEY_*)') -> fetch -> groupby('plugin_instance') -> stats:!sum -> _SF_PLOT_KEY_##CHARTID##_2_21 -> groupby() -> sample(100) -> split -> publish(metric='_SF_PLOT_KEY_##CHARTID##_2_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK:!OUT->_SF_PLOT_KEY_##CHARTID##_3_21->groupby() -> sample(100) -> split->publish(metric='_SF_PLOT_KEY_##CHARTID##_3_21',sf_uiAnalyticsDerivedMetric=1,sf_uiHelper='##CHARTID##_21');_SF_PLOT_KEY_##CHARTID##_1_21->?A:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK;_SF_PLOT_KEY_##CHARTID##_2_21->?B:_SF_PLOT_KEY_##CHARTID##_3_21_MACROBLOCK"
 } ]

--- a/collectd-elasticsearch/docs/counter.thread_pool.bulk.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.bulk.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Bulk Requests
 
-> The number of bulk requests that have been rejected on this node since it started.
+> The number of bulk requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the bulk request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.flush.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.flush.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Flush Requests
 
-> The number of flush requests that have been rejected on this node since it started.
+> The number of flush requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the flush request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.generic.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.generic.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Generic Requests
 
-> The number of generic requests that have been rejected on this node since it started.
+> The number of generic requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the generic request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.get.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.get.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Get Requests
 
-> The number of get requests that have been rejected on this node since it started.
+> The number of get requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the get request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.index.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.index.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Index Requests
 
-> The number of index requests that have been rejected on this node since it started.
+> The number of index requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the index request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.merge.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.merge.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Merge Requests
 
-> The number of merge requests that have been rejected on this node since it started.
+> The number of merge requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the merge request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.optimize.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.optimize.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Optimize Requests
 
-> The number of optimize requests that have been rejected on this node since it started.
+> The number of optimize requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the optimize request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.refresh.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.refresh.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Refresh Requests
 
-> The number of refresh requests that have been rejected on this node since it started.
+> The number of refresh requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the refresh request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.rejected.md
@@ -1,0 +1,42 @@
+---
+title: Rejected Thread Pool Requests
+brief: Number of rejected thread pool requests
+metric_type: counter
+---
+### Rejected Requests
+
+> The number of requests that have been rejected per thread pool on this node since it started.
+
+
+If the get request queue fills up to its limit, new work units will begin to be
+rejected, and you will see that reflected in this rejected metric. This is 
+often a sign that your cluster is starting to bottleneck on some resources, 
+since a full queue means your node/cluster is processing at maximum speed but 
+unable to keep up with the influx of work.
+
+Number of rejected requests for a given thread pool.  The represented thread pool is indicated by the dimension "thread_pool".
+
+
+The following thread pools may be configured:
+
+|Thread Pool|Description|Configured By Default|
+|-----------|-----------|---------------------|
+|bulk|The number of bulk requests that have been rejected on this node since it started.|False|
+|force_merge|The number of force merges that have been rejected on this node since it started|False|
+|fetch_shard_started|The number of fetch_shard_started requests that have been rejected on this node since it started|False|
+|fetch_shard_store|The number of fetch_shard_store requests that have been rejected on this node since it started|False|
+|flush|The number of flush requests that have been rejected on this node since it started.|False|
+|generic|The number of generic requests that have been rejected on this node since it started.|False|
+|get|The number of get requests that have been rejected on this node since it started.|False|
+|index|The number of index requests that have been rejected on this node since it started.|True|
+|listener|The number of listener requests that have been rejected on this node since it started|False|
+|management|The number of management requests that have been rejected on this node since it started|False|
+|merge|The number of merge requests that have been rejected on this node since it started.|False|
+|optimize|The number of optimize requests that have been rejected on this node since it started.|False|
+|percolate|The number of percolate requests that have been rejected on this node since it started.|False|
+|refresh|The number of refresh requests that have been rejected on this node since it started.|False|
+|search|The number of search requests that have been rejected on this node since it started.|True|
+|snapshot|The number of snapshot requests that have been rejected on this node since it started.|False|
+|suggest|The number of suggest requests that have been rejected on this node since it started|False|
+|warmer|The number of warmer requests that have been rejected on this node since it started|False|
+

--- a/collectd-elasticsearch/docs/counter.thread_pool.search.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.search.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Search Requests
 
-> The number of search requests that have been rejected on this node since it started.
+> The number of search requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the search request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.

--- a/collectd-elasticsearch/docs/counter.thread_pool.snapshot.rejected.md
+++ b/collectd-elasticsearch/docs/counter.thread_pool.snapshot.rejected.md
@@ -5,6 +5,6 @@ metric_type: counter
 ---
 ### Rejected Snapshot Requests
 
-> The number of snapshot requests that have been rejected on this node since it started.
+> The number of snapshot requests that have been rejected on this node since it started. Superseded by `counter.thread_pool.rejected`.
 
 If the snapshot request queue fills up to its limit, new work units will begin to be rejected, and you will see that reflected in this rejected metric. This is often a sign that your cluster is starting to bottleneck on some resources, since a full queue means your node/cluster is processing at maximum speed but unable to keep up with the influx of work.


### PR DESCRIPTION
Remove doc for deprecated metrics
Add doc for new threadpool.rejected metric and dimensions
Turn on index stats by default in elasticsearch conf file