### PR TITLE
Fix code blocks, underscores as italics in aws services tables

### DIFF
--- a/aws-ebs/README.md
+++ b/aws-ebs/README.md
@@ -8,25 +8,25 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Amazon Elastic Block Store (EBS) via [Amazon CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws). 
+Use SignalFx to monitor Amazon Elastic Block Store (EBS) via [Amazon CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws).
 
 #### FEATURES
 
 ##### Built-in dashboards
 
 - **EBS Volumes**: Overview of all data from EBS.
-  
+
   [<img src='./img/dashboard_ebs_volumes.png' width=200px>](./img/dashboard_ebs_volumes.png)
 
 - **EBS Volume**: Focus on a single EBS volume.
-  
+
   [<img src='./img/dashboard_ebs_volume.png' width=200px>](./img/dashboard_ebs_volume.png)
 
 ### INSTALLATION
 
-To access this integration, [connect to CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws) on the SignalFx Integrations page. 
+To access this integration, [connect to CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws) on the SignalFx Integrations page.
 
-By default, SignalFx will import all CloudWatch metrics that are available in your account. To retrieve metrics for a subset of available services or regions, modify the connection on the Integrations page. 
+By default, SignalFx will import all CloudWatch metrics that are available in your account. To retrieve metrics for a subset of available services or regions, modify the connection on the Integrations page.
 
 ### USAGE
 
@@ -34,22 +34,22 @@ By default, SignalFx will import all CloudWatch metrics that are available in yo
 
 SignalFx synthesizes a unique ID for each EBS volume in the dimension `AWSUniqueId`.
 
-#### EBS metadata 
+#### EBS metadata
 
 For EBS, SignalFx will scan every volume ID from your AWS account and pull out properties of the volume and any tags set on the volume.
 
 | EBS Filter Name	| Custom Property	| Description |
 |-----------------|-----------------|-------------|
-| availability-zone	| aws_availability_zone |	The Availability Zone in which the volume was created |
-| create-time	| aws_create_time |	The time stamp when the volume was created |
+| availability-zone	| aws\_availability\_zone |	The Availability Zone in which the volume was created |
+| create-time	| aws\_create\_time |	The time stamp when the volume was created |
 | encrypted	| aws_encrypted |	The encryption status of the volume |
-| iops	| aws_iops |	The number of I/O operations per second (IOPS) that the volume supports |
-| kms_key_id	| aws_kms_key_id |	The full ARN of the AWS customer master key used to protect the volume encryption key for the volume |
-| size	| aws_size |	The size of the volume, in GiB |
-| snapshot_id	| aws_snapshot_id |	The snapshot from which the volume was created |
-| state	| aws_state |	The status of the volume |
-| volume_id	| aws_volume_id |	The volume ID |
-| volume_type	| aws_volume_type |	The Amazon EBS volume type |
+| iops	| aws\_iops | The number of I/O operations per second (IOPS) that the volume supports |
+| kms_key_id	| aws\_kms\_key\_id | The full ARN of the AWS customer master key used to protect the volume encryption key for the volume |
+| size	| aws\_size | The size of the volume, in GiB |
+| snapshot_id	| aws\_snapshot\_id |	The snapshot from which the volume was created |
+| state	| aws\_state |	The status of the volume |
+| volume_id	| aws\_volume\_id |	The volume ID |
+| volume_type	| aws\_volume\_type |	The Amazon EBS volume type |
 
 ### METRICS
 

--- a/aws-elb/README.md
+++ b/aws-elb/README.md
@@ -8,25 +8,25 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Elastic Load Balancing (ELB) via [Amazon CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws). 
+Use SignalFx to monitor Elastic Load Balancing (ELB) via [Amazon CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws).
 
 #### FEATURES
 
 ##### Built-in dashboards
 
 - **ELB Instances**: Overview of all data from ELB.
-  
+
   [<img src='./img/dashboard_elb_instances.png' width=200px>](./img/dashboard_elb_instances.png)
 
 - **ELB Instance**: Focus on a single ELB load balancer.
-  
+
   [<img src='./img/dashboard_elb_instance.png' width=200px>](./img/dashboard_elb_instance.png)
 
 ### INSTALLATION
 
-To access this integration, [connect to CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws) on the SignalFx Integrations page. 
+To access this integration, [connect to CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws) on the SignalFx Integrations page.
 
-By default, SignalFx will import all CloudWatch metrics that are available in your account. To retrieve metrics for a subset of available services or regions, modify the connection on the Integrations page. 
+By default, SignalFx will import all CloudWatch metrics that are available in your account. To retrieve metrics for a subset of available services or regions, modify the connection on the Integrations page.
 
 ### USAGE
 
@@ -34,13 +34,13 @@ By default, SignalFx will import all CloudWatch metrics that are available in yo
 
 SignalFx synthesizes a unique ID for each ELB in the dimension `AWSUniqueId`.
 
-#### ELB metadata 
+#### ELB metadata
 
 For ELB, SignalFx will scan every load balancer name from your AWS account and pull out properties of the load balancer and any tags set on the load balancer.
 
 | ELB Filter Name |	Custom Property |	Description |
 |-----------------|-----------------|-------------|
-| create-time |	aws_create_time	| The time stamp when the load balancer was created |
+| create-time | aws\_create\_time | The time stamp when the load balancer was created |
 
 ### METRICS
 


### PR DESCRIPTION
The extra space at the beginnings of table cells was causing code formatting and the unescaped underscores were being interpreted as italics.