### PR TITLE
Correct default value for ModulePath

### DIFF
--- a/collectd-mongodb/README.md
+++ b/collectd-mongodb/README.md
@@ -87,7 +87,7 @@ Using the example configuration file [10-mongodb.conf](https://github.com/signal
 
 | configuration option | definition | default value |
 | ---------------------|------------|---------------|
-| ModulePath | Path on disk where collectd can find this module. | "/opt/setup/scripts" |
+| ModulePath | Path on disk where collectd can find this module. | "/usr/share/collectd/mongodb-collectd-plugin" |
 | Host | Host IP | "127.0.0.1" |
 | Port | Port number for IP connection | "27017" |
 | User | Valid mongodb user | "" |


### PR DESCRIPTION
Changed the default value for ModulePath in the README to
"/usr/share/collectd/mongodb-collectd-plugin" to be consistent with the
default location for it in our example configuration file, where Chef
and Puppet deploys it to by default ,etc.