### PR TITLE
Fixed ModulePath inconsistencies

### DIFF
--- a/collectd-mesos/10-mesos-master.conf
+++ b/collectd-mesos/10-mesos-master.conf
@@ -4,7 +4,7 @@
 #     apt-get install collectd-python
 #
 #   Install the collectd plugin from github:
-#     git clone https://github.com/signalfx/collectd-mesos /opt/collectd-mesos
+#     git clone https://github.com/signalfx/collectd-mesos /usr/share/collectd/mesos-collectd-plugin
 #
 # Documentation:
 #   https://github.com/signalfx/collectd-mesos
@@ -25,7 +25,7 @@
 </LoadPlugin>
 
 <Plugin "python">
-  ModulePath "/opt/collectd-mesos"
+  ModulePath "/usr/share/collectd/mesos-collectd-plugin"
 
   Import "mesos-master"
 

--- a/collectd-mesos/10-mesos-slave.conf
+++ b/collectd-mesos/10-mesos-slave.conf
@@ -4,7 +4,7 @@
 #     apt-get install collectd-python
 #
 #   Install the collectd plugin from github:
-#     git clone https://github.com/signalfx/collectd-mesos /opt/collectd-mesos
+#     git clone https://github.com/signalfx/collectd-mesos /usr/share/collectd/mesos-collectd-plugin
 #
 # Documentation:
 #   https://github.com/signalfx/collectd-mesos
@@ -25,7 +25,7 @@
 </LoadPlugin>
 
 <Plugin "python">
-  ModulePath "/opt/collectd-mesos"
+  ModulePath "/usr/share/collectd/mesos-collectd-plugin"
 
   Import "mesos-slave"
 

--- a/collectd-mesos/README.md
+++ b/collectd-mesos/README.md
@@ -61,7 +61,7 @@ Using the example configuration files [`10-mesos-master.conf`](././10-mesos-mast
 
 | configuration option | definition | default value |
 | ---------------------|------------|---------------|
-| ModulePath | Path on disk where collectd can find this module. | "/opt/collectd-mesos" |
+| ModulePath | Path on disk where collectd can find this module. | "/usr/share/collectd/mesos-collectd-plugin" |
 | Cluster | The name of the cluster to which the Mesos instance belongs. Appears in the dimension `cluster`. | "cluster-0" |
 | Instance | The name of this Mesos master/slave instance. Appears in the dimension `plugin_instance`. | "master-0" / "slave-0" |
 | Path | The location of the mesos-master/mesos-slave binary. | "/usr/sbin" |


### PR DESCRIPTION
Mesos .conf files and README are no longer inconsistent from a ModulePath perspective with respect to
other integrations and the Chef/Puppet deployment of Mesos.