### PR TITLE
PostgreSQL config files and README improvements

### DIFF
--- a/collectd-postgresql/10-postgresql.conf
+++ b/collectd-postgresql/10-postgresql.conf
@@ -8,6 +8,12 @@
 # Config file modifications:
 #   Change the hostname to location of the postgresql host, username and password.
 
+#	If desired, change the name of the database from the default of "postgres" within the starting
+#	tag of the <Database> block. This name is what will be reported on the plugin_instance dimension
+#	for metrics coming from this database.
+
+#	If you wish to monitor multiple databases, create a new <Database> block and repeat the above steps.
+
 LoadPlugin postgresql
 
 <Plugin postgresql>

--- a/collectd-postgresql/10-postgresql_pre92.conf
+++ b/collectd-postgresql/10-postgresql_pre92.conf
@@ -8,6 +8,12 @@
 # Config file modifications:
 #   Change the hostname to location of the postgresql host, username and password.
 
+#	If desired, change the name of the database from the default of "postgres" within the starting
+#	tag of the <Database> block. This name is what will be reported on the plugin_instance dimension
+#	for metrics coming from this database.
+
+#	If you wish to monitor multiple databases, create a new <Database> block and repeat the above steps.
+
 LoadPlugin postgresql
 
 <Plugin postgresql>

--- a/collectd-postgresql/README.md
+++ b/collectd-postgresql/README.md
@@ -65,7 +65,7 @@ Using the example configuration file [10-postgresql.conf](https://github.com/sig
 | User  | Username that collectd will use to access PostgreSQL | collectd_user |
 | Password  | Password for the user specified in User | Password123 |
 
-No additional configuration is necessary if using SignalFx's example configuration file. For complete documentation of configuration options, see [collectd's manpage for this plugin](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_postgresql).
+No additional configuration is necessary if you are using SignalFx's example configuration file. However, you may wish to change the name of the database from the default of "postgres" within the starting tag of the `<Database>` block. This name is what will be reported on the plugin_instance dimension for metrics coming from this database. For complete documentation of configuration options, see [collectd's manpage for this plugin](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_postgresql).
 
 #### System modifications
 


### PR DESCRIPTION
Add note to README and example configuration files that the database
name that is reported via plugin_instance is an optionally-configurable
setting (and how they would change it)

Add note to example configuration files on how one would configure the
monitoring of multiple databases.