### PR TITLE
Improve Kafka Integration README

### DIFF
--- a/collectd-kafka/README.md
+++ b/collectd-kafka/README.md
@@ -38,12 +38,12 @@ This is the Kafka plugin for collectd. It will send data about Kafka to SignalFx
 
 1. RHEL/CentOS and Amazon Linux users: Install the [Java plugin for collectd](https://github.com/signalfx/integrations/tree/master/collectd-java)[](sfx_link:collectd-java) if it is not already installed. 
 
-1. Download SignalFx's example Kafka configuration file to `/etc/collectd/managed_config`:  [20-kafka.conf](https://github.com/signalfx/integrations/blob/master/collectd-kafka/20-kafka.conf)
+1. Download SignalFx's example Kafka configuration file to `/etc/collectd/managed_config`:  [20-kafka_82.conf](https://github.com/signalfx/integrations/blob/master/collectd-kafka/20-kafka_82.conf)
 
-  *Note: If you're using Kafka v0.8.2, download this sample Kafka configuration file instead:*
-[20-kafka_82.conf](https://github.com/signalfx/integrations/blob/master/collectd-kafka/20-kafka_82.conf)
+  *Note: If you're using a version of Kafka earlier than v0.8.2, download this sample Kafka configuration file instead:*
+[20-kafka.conf](https://github.com/signalfx/integrations/blob/master/collectd-kafka/20-kafka.conf)
 
-1. Modify `20-kafka.conf` to provide values that make sense for your environment, as described in [Configuration](#configuration), below.
+1. Modify your Kafka configuration file to provide values that make sense for your environment, as described in [Configuration](#configuration), below.
 
 1. Restart collectd.
 


### PR DESCRIPTION
Clarify which versions of the Kafka configuration file map to which
versions of Kafka

Make the link to version of the configuration file for Kafka v0.8.2 and
above the default one suggested (instead of defaulting to the one for earlier versions)