### PR TITLE
CloudFront only in us-east-1

### DIFF
--- a/aws-cloudfront/README.md
+++ b/aws-cloudfront/README.md
@@ -25,7 +25,7 @@ Use SignalFx to monitor Amazon CloudFront via [Amazon CloudWatch](https://github
 
 To access this integration, [connect to CloudWatch](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws) on the SignalFx Integrations page. 
 
-By default, SignalFx will import all CloudWatch metrics that are available in your account. To retrieve metrics for a subset of available services or regions, modify the connection on the Integrations page. 
+Note that CloudWatch metrics for CloudFront are reported only from region `us-east-1` (US East/N. Virginia). To import metrics for CloudFront, ensure that your CloudWatch configuration includes metrics from `us-east-1`. 
 
 ### USAGE
 


### PR DESCRIPTION
Noting that us-east-1 collection must be enabled.