### PR TITLE
Adding a lot of CF metrics and updating README

### DIFF
--- a/cloudfoundry/README.md
+++ b/cloudfoundry/README.md
@@ -35,52 +35,22 @@ This integration includes built-in dashboards listed under **Pivotal Cloud Found
 
 ### REQUIREMENTS AND DEPENDENCIES
 
-This integration requires administrative access to a Pivotal Cloud Foundry deployment with the JMX Bridge installed. Pivotal Web Services is not supported. Versions known to work are:
+This integration requires administrative access to a Pivotal Cloud Foundry deployment. Pivotal Web Services is not supported. Versions known to work are:
 
 | Software                | Version        |
 |-------------------------|----------------|
 | Pivotal Ops Manager     | 1.9.1+ |
 | Pivotal Elastic Runtime | 1.9.0+ |
-| Pivotal JMX Bridge      | 1.8.11+ |
 
 ### INSTALLATION
 
 Follow these steps to enable this integration:
 
-1. Download the product file from [Pivotal Network](https://network.pivotal.io) or from [SignalFx's Github repository](https://github.com/signalfx/cloudfoundry-integration/releases/download/v0.9.0/signalfx-agent-0.9.0.pivotal).
+1. Download the product file from [Pivotal Network](https://network.pivotal.io/products/signalfx-monitoring-alerting/).
 
-1. Navigate to the Ops Manager Installation Dashboard and click "Import a Product" to upload the product file. 
+1. Follow the [installation instructions for the tile](http://docs.pivotal.io/partners/signalfx/installing.html).
 
-1. Under "Import a Product", click "+" next to the version number of SignalFx Monitoring and Alerting for PCF. This adds the tile to your staging area.
-
-1. Click the newly added SignalFx Monitoring and Alerting for PCF tile.
-
-1. In the SignalFx section, enter your SignalFx [access token](http://docs.signalfx.com/en/latest/admin-guide/tokens.html#tokens). Leave the SignalFx ingestion URL unchanged.
-
-1. In the Pivotal JMX Bridge section, copy configuration values from the JMX Bridge tile. 
-
-  1. To find the JMX IP Address, select the JMX Bridge tile in PCF Ops Manager and choose the Status tab. Copy the IP address from the job called "JMX Provider". 
-
-  1. To find JMX username, JMX password, and (if applicable) JMX SSL certificate, select the JMX Bridge tile in PCF Ops Manager and choose the "Settings" tab. Select the "JMX Provider" section, then copy over the JMX credentials and SSL certificate. 
-
-1. Click Save.
-
-1. Return to the Ops Manager Installation Dashboard and click "Apply Changes" to install the SignalFx Monitoring and Alerting for PCF tile.
-
-Metrics from Pivotal Cloud Foundry will begin streaming into SignalFx. 
-
-#### Troubleshooting
-
-If metrics from Pivotal Cloud Foundry don't appear in SignalFx after more than a few minutes, check the following:
-
-* Verify that the values in the Pivotal JMX Bridge settings section of the SignalFx tile match the settings of the JMX Bridge tile.
-
-* Check the logs of the deployed SignalFx Agent for errors, such as connection issues to the JMX Bridge, SSL certificate errors with the JMX Bridge, or errors reporting metrics to SignalFx. 
-
-* Ensure that the app called signalfx-agent is running. 
-  1. Log into [Pivotal Apps Manager](https://docs.pivotal.io/pivotalcf/1-9/customizing/console-login.html). 
-  1. Inside the space signalfx-agent-space there will be an app named `signalfx-agent`. 
-  1. Ensure that `signalfx-agent` is in the "running" state. 
+Metrics from Pivotal Cloud Foundry should begin streaming into SignalFx.
 
 ### METRICS
 

--- a/cloudfoundry/README.md
+++ b/cloudfoundry/README.md
@@ -29,7 +29,7 @@ This integration includes built-in dashboards listed under **Pivotal Cloud Found
   
   [<img src='./img/dashboard_cloud_foundry_overview.png' width=200px>](./img/dashboard_cloud_foundry_overview.png)
 
-- **Cloud Foundry Instance**: Focus on a single Cloud Foundry instance.
+- **Cloud Foundry Architecture**: Focus on a single Cloud Foundry instance.
   
   [<img src='./img/dashboard_cloud_foundry_instance.png' width=200px>](./img/dashboard_cloud_foundry_instance.png)
 
@@ -51,6 +51,14 @@ Follow these steps to enable this integration:
 1. Follow the [installation instructions for the tile](http://docs.pivotal.io/partners/signalfx/installing.html).
 
 Metrics from Pivotal Cloud Foundry should begin streaming into SignalFx.
+
+To monitor services running within **Garden containers** (e.g. webservers) you will
+need to use [our buildpack
+decorator](https://github.com/signalfx/signalfx-cloudfoundry-buildpack-decorator)
+along with the CF meta-buildpack.
+
+To get our agent on to your own **BOSH deployments**, you can use [our BOSH
+release](https://github.com/signalfx/agent-boshrelease).
 
 ### METRICS
 

--- a/cloudfoundry/docs/DopplerServer.LinuxFileDescriptor.md
+++ b/cloudfoundry/docs/DopplerServer.LinuxFileDescriptor.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Linux File Descriptor
+brief: Number of file handles for the Doppler’s process.
+metric_type: gauge
+---
+
+### Doppler Server Linux File Descriptor
+
+Number of file handles for the Doppler’s process.

--- a/cloudfoundry/docs/DopplerServer.TruncatingBuffer.DroppedMessages.md
+++ b/cloudfoundry/docs/DopplerServer.TruncatingBuffer.DroppedMessages.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Truncating Buffer Dropped Messages
+brief: Number of messages intentionally dropped by Doppler from the sink for the specific sink. This counter event will correspond with log messages “Log message output is too high.” Emitted every 5 seconds.
+metric_type: gauge
+---
+
+### Doppler Server Truncating Buffer Dropped Messages
+
+Number of messages intentionally dropped by Doppler from the sink for the specific sink. This counter event will correspond with log messages “Log message output is too high.” Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.TruncatingBuffer.totalDroppedMessages.md
+++ b/cloudfoundry/docs/DopplerServer.TruncatingBuffer.totalDroppedMessages.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Truncating Buffer Total Dropped Messages
+brief: Lifetime total number of messages intentionally dropped by Doppler from all of its sinks due to back pressure. Emitted every 5 seconds.
+metric_type: gauge
+---
+
+### Doppler Server Truncating Buffer Total Dropped Messages
+
+Lifetime total number of messages intentionally dropped by Doppler from all of its sinks due to back pressure. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.Uptime.md
+++ b/cloudfoundry/docs/DopplerServer.Uptime.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Uptime
+brief: Uptime for the Doppler’s process.
+metric_type: gauge
+---
+
+### Doppler Server Uptime
+
+Uptime for the Doppler’s process.

--- a/cloudfoundry/docs/DopplerServer.dropsondeListener.currentBufferCount.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeListener.currentBufferCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Listener Current Buffer Count
+brief: DEPRECATED
+metric_type: cumulative_counter
+---
+
+### Doppler Server Dropsonde Listener Current Buffer Count
+
+DEPRECATED

--- a/cloudfoundry/docs/DopplerServer.dropsondeListener.receivedByteCount.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeListener.receivedByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Listener Received Byte Count
+brief: DEPRECATED in favor of DopplerServer.udpListener.receivedByteCount.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Dropsonde Listener Received Byte Count
+
+DEPRECATED in favor of DopplerServer.udpListener.receivedByteCount.

--- a/cloudfoundry/docs/DopplerServer.dropsondeListener.receivedMessageCount.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeListener.receivedMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Listener Received Message Count
+brief: DEPRECATED in favor of DopplerServer.udpListener.receivedMessageCount.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Dropsonde Listener Received Message Count
+
+DEPRECATED in favor of DopplerServer.udpListener.receivedMessageCount.

--- a/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.containerMetricReceived.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.containerMetricReceived.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Unmarshaller Container Metric Received
+brief: Lifetime number of ContainerMetric messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Dropsonde Unmarshaller Container Metric Received
+
+Lifetime number of ContainerMetric messages unmarshalled.

--- a/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.counterEventReceived.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.counterEventReceived.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Unmarshaller Counter Event Received
+brief: Lifetime number of CounterEvent messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Dropsonde Unmarshaller Counter Event Received
+
+Lifetime number of CounterEvent messages unmarshalled.

--- a/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.errorReceived.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.errorReceived.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Unmarshaller Error Received
+brief: Lifetime number of Error messages unmarshalled.
+metric_type: gauge
+---
+
+### Doppler Server Dropsonde Unmarshaller Error Received
+
+Lifetime number of Error messages unmarshalled.

--- a/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.heartbeatReceived.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.heartbeatReceived.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Unmarshaller Heartbeat Received
+brief: DEPRECATED
+metric_type: gauge
+---
+
+### Doppler Server Dropsonde Unmarshaller Heartbeat Received
+
+DEPRECATED

--- a/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.httpStartStopReceived.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.httpStartStopReceived.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Unmarshaller HTTP Start Stop Received
+brief: Lifetime number of HttpStartStop messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Dropsonde Unmarshaller HTTP Start Stop Received
+
+Lifetime number of HttpStartStop messages unmarshalled.

--- a/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.logMessageTotal.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.logMessageTotal.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Unmarshaller Log Message Total
+brief: Lifetime number of LogMessage messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Dropsonde Unmarshaller Log Message Total
+
+Lifetime number of LogMessage messages unmarshalled.

--- a/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.unmarshalErrors.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.unmarshalErrors.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Unmarshaller Unmarshal Errors
+brief: Lifetime number of errors when unmarshalling messages.
+metric_type: gauge
+---
+
+### Doppler Server Dropsonde Unmarshaller Unmarshal Errors
+
+Lifetime number of errors when unmarshalling messages.

--- a/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.valueMetricReceived.md
+++ b/cloudfoundry/docs/DopplerServer.dropsondeUnmarshaller.valueMetricReceived.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Dropsonde Unmarshaller Value Metric Received
+brief: Lifetime number of ValueMetric messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Dropsonde Unmarshaller Value Metric Received
+
+Lifetime number of ValueMetric messages unmarshalled.

--- a/cloudfoundry/docs/DopplerServer.httpServer.receivedMessages.md
+++ b/cloudfoundry/docs/DopplerServer.httpServer.receivedMessages.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server HTTP Server Received Messages
+brief: Number of messages received by Doppler’s internal MessageRouter. Emitted every 5 seconds.
+metric_type: cumulative_counter
+---
+
+### Doppler Server HTTP Server Received Messages
+
+Number of messages received by Doppler’s internal MessageRouter. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.listeners.totalReceivedMessageCount.md
+++ b/cloudfoundry/docs/DopplerServer.listeners.totalReceivedMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Listeners Total Received Message Count
+brief: Total number of messages received across all of Doppler’s listeners (UDP, TCP, TLS).
+metric_type: cumulative_counter
+---
+
+### Doppler Server Listeners Total Received Message Count
+
+Total number of messages received across all of Doppler’s listeners (UDP, TCP, TLS).

--- a/cloudfoundry/docs/DopplerServer.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/DopplerServer.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Memory Stats Last GC Pause Time NS
+brief: Duration of the last Garbage Collector pause in nanoseconds.
+metric_type: gauge
+---
+
+### Doppler Server Memory Stats Last GC Pause Time NS
+
+Duration of the last Garbage Collector pause in nanoseconds.

--- a/cloudfoundry/docs/DopplerServer.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/DopplerServer.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Doppler Server Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/DopplerServer.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/DopplerServer.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Doppler Server Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/DopplerServer.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/DopplerServer.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Doppler Server Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/DopplerServer.messageRouter.numberOfContainerMetricSinks.md
+++ b/cloudfoundry/docs/DopplerServer.messageRouter.numberOfContainerMetricSinks.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Message Router Number of Container Metric Sinks
+brief: Instantaneous number of container metric sinks known to the SinkManager. Emitted every 5 seconds.
+metric_type: gauge
+---
+
+### Doppler Server Message Router Number of Container Metric Sinks
+
+Instantaneous number of container metric sinks known to the SinkManager. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.messageRouter.numberOfDumpSinks.md
+++ b/cloudfoundry/docs/DopplerServer.messageRouter.numberOfDumpSinks.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Message Router Number of Dump Sinks
+brief: Instantaneous number of dump sinks known to the SinkManager. Emitted every 5 seconds.
+metric_type: gauge
+---
+
+### Doppler Server Message Router Number of Dump Sinks
+
+Instantaneous number of dump sinks known to the SinkManager. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.messageRouter.numberOfFirehoseSinks.md
+++ b/cloudfoundry/docs/DopplerServer.messageRouter.numberOfFirehoseSinks.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Message Router Number of Firehose Sinks
+brief: Instantaneous number of firehose sinks known to the SinkManager. Emitted every 5 seconds.
+metric_type: gauge
+---
+
+### Doppler Server Message Router Number of Firehose Sinks
+
+Instantaneous number of firehose sinks known to the SinkManager. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.messageRouter.numberOfSyslogSinks.md
+++ b/cloudfoundry/docs/DopplerServer.messageRouter.numberOfSyslogSinks.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Message Router Number of Syslog Sinks
+brief: Instantaneous number of syslog sinks known to the SinkManager.
+metric_type: gauge
+---
+
+### Doppler Server Message Router Number of Syslog Sinks
+
+Instantaneous number of syslog sinks known to the SinkManager.

--- a/cloudfoundry/docs/DopplerServer.messageRouter.numberOfWebsocketSinks.md
+++ b/cloudfoundry/docs/DopplerServer.messageRouter.numberOfWebsocketSinks.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Message Router Number of Websocket Sinks
+brief: Instantaneous number of WebSocket sinks known to the SinkManager. Emitted every 5 seconds.
+metric_type: gauge
+---
+
+### Doppler Server Message Router Number of Websocket Sinks
+
+Instantaneous number of WebSocket sinks known to the SinkManager. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.messageRouter.totalDroppedMessages.md
+++ b/cloudfoundry/docs/DopplerServer.messageRouter.totalDroppedMessages.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Message Router Total Dropped Messages
+brief: Lifetime number of messages dropped inside Doppler for various reasons (downstream consumer can’t keep up internal object wasn’t ready for message, etc.).
+metric_type: gauge
+---
+
+### Doppler Server Message Router Total Dropped Messages
+
+Lifetime number of messages dropped inside Doppler for various reasons (downstream consumer can’t keep up internal object wasn’t ready for message, etc.).

--- a/cloudfoundry/docs/DopplerServer.numCpus.md
+++ b/cloudfoundry/docs/DopplerServer.numCpus.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Num Cpus
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Doppler Server Num Cpus
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/DopplerServer.numGoRoutines.md
+++ b/cloudfoundry/docs/DopplerServer.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Num Go Routines
+brief: Instantaneous number of active goroutines in the Doppler process.
+metric_type: gauge
+---
+
+### Doppler Server Num Go Routines
+
+Instantaneous number of active goroutines in the Doppler process.

--- a/cloudfoundry/docs/DopplerServer.sentMessagesFirehose.<SUBSCRIPTION_ID>.md
+++ b/cloudfoundry/docs/DopplerServer.sentMessagesFirehose.<SUBSCRIPTION_ID>.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Sent Messages Firehose <SUBSCRIPTION ID>
+brief: Number of sent messages through the firehose per subscription id. Emitted every 5 seconds.
+metric_type: gauge
+---
+
+### Doppler Server Sent Messages Firehose <SUBSCRIPTION ID>
+
+Number of sent messages through the firehose per subscription id. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.signatureVerifier.invalidSignatureErrors.md
+++ b/cloudfoundry/docs/DopplerServer.signatureVerifier.invalidSignatureErrors.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Signature Verifier Invalid Signature Errors
+brief: Lifetime number of messages received with an invalid signature.
+metric_type: gauge
+---
+
+### Doppler Server Signature Verifier Invalid Signature Errors
+
+Lifetime number of messages received with an invalid signature.

--- a/cloudfoundry/docs/DopplerServer.signatureVerifier.missingSignatureErrors.md
+++ b/cloudfoundry/docs/DopplerServer.signatureVerifier.missingSignatureErrors.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Signature Verifier Missing Signature Errors
+brief: Lifetime number of messages received that are too small to contain a signature.
+metric_type: gauge
+---
+
+### Doppler Server Signature Verifier Missing Signature Errors
+
+Lifetime number of messages received that are too small to contain a signature.

--- a/cloudfoundry/docs/DopplerServer.signatureVerifier.validSignatures.md
+++ b/cloudfoundry/docs/DopplerServer.signatureVerifier.validSignatures.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Signature Verifier Valid Signatures
+brief: Lifetime number of messages received with valid signatures.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Signature Verifier Valid Signatures
+
+Lifetime number of messages received with valid signatures.

--- a/cloudfoundry/docs/DopplerServer.tcpListener.receivedByteCount.md
+++ b/cloudfoundry/docs/DopplerServer.tcpListener.receivedByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server TCP Listener Received Byte Count
+brief: Lifetime number of bytes received by Doppler’s TCP Listener. Emitted every 5 seconds.
+metric_type: cumulative_counter
+---
+
+### Doppler Server TCP Listener Received Byte Count
+
+Lifetime number of bytes received by Doppler’s TCP Listener. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.tcpListener.receivedErrorCount.md
+++ b/cloudfoundry/docs/DopplerServer.tcpListener.receivedErrorCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server TCP Listener Received Error Count
+brief: Lifetime number of errors encountered by Doppler’s TCP Listener while handshaking, decoding or reading from the connection.
+metric_type: cumulative_counter
+---
+
+### Doppler Server TCP Listener Received Error Count
+
+Lifetime number of errors encountered by Doppler’s TCP Listener while handshaking, decoding or reading from the connection.

--- a/cloudfoundry/docs/DopplerServer.tcpListener.receivedMessageCount.md
+++ b/cloudfoundry/docs/DopplerServer.tcpListener.receivedMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server TCP Listener Received Message Count
+brief: Lifetime number of messages received by Doppler’s TCP Listener. Emitted every 5 seconds.
+metric_type: cumulative_counter
+---
+
+### Doppler Server TCP Listener Received Message Count
+
+Lifetime number of messages received by Doppler’s TCP Listener. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.tlsListener.receivedByteCount.md
+++ b/cloudfoundry/docs/DopplerServer.tlsListener.receivedByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Tls Listener Received Byte Count
+brief: Lifetime number of bytes received by Doppler’s TLS Listener. Emitted every 5 seconds.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Tls Listener Received Byte Count
+
+Lifetime number of bytes received by Doppler’s TLS Listener. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.tlsListener.receivedErrorCount.md
+++ b/cloudfoundry/docs/DopplerServer.tlsListener.receivedErrorCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Tls Listener Received Error Count
+brief: Lifetime number of errors encountered by Doppler’s TLS Listener while handshaking, decoding or reading from the connection.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Tls Listener Received Error Count
+
+Lifetime number of errors encountered by Doppler’s TLS Listener while handshaking, decoding or reading from the connection.

--- a/cloudfoundry/docs/DopplerServer.tlsListener.receivedMessageCount.md
+++ b/cloudfoundry/docs/DopplerServer.tlsListener.receivedMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server Tls Listener Received Message Count
+brief: Lifetime number of messages received by Doppler’s TLS Listener. Emitted every 5 seconds.
+metric_type: cumulative_counter
+---
+
+### Doppler Server Tls Listener Received Message Count
+
+Lifetime number of messages received by Doppler’s TLS Listener. Emitted every 5 seconds.

--- a/cloudfoundry/docs/DopplerServer.udpListener.receivedByteCount.md
+++ b/cloudfoundry/docs/DopplerServer.udpListener.receivedByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server UDP Listener Received Byte Count
+brief: Lifetime number of bytes received by Doppler’s UDP Listener.
+metric_type: cumulative_counter
+---
+
+### Doppler Server UDP Listener Received Byte Count
+
+Lifetime number of bytes received by Doppler’s UDP Listener.

--- a/cloudfoundry/docs/DopplerServer.udpListener.receivedErrorCount.md
+++ b/cloudfoundry/docs/DopplerServer.udpListener.receivedErrorCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server UDP Listener Received Error Count
+brief: Lifetime number of errors encountered by Doppler’s UDP Listener while reading from the connection.
+metric_type: cumulative_counter
+---
+
+### Doppler Server UDP Listener Received Error Count
+
+Lifetime number of errors encountered by Doppler’s UDP Listener while reading from the connection.

--- a/cloudfoundry/docs/DopplerServer.udpListener.receivedMessageCount.md
+++ b/cloudfoundry/docs/DopplerServer.udpListener.receivedMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Doppler Server UDP Listener Received Message Count
+brief: Lifetime number of messages received by Doppler’s UDP Listener.
+metric_type: cumulative_counter
+---
+
+### Doppler Server UDP Listener Received Message Count
+
+Lifetime number of messages received by Doppler’s UDP Listener.

--- a/cloudfoundry/docs/LoggregatorTrafficController.LinuxFileDescriptor.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.LinuxFileDescriptor.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Linux File Descriptor
+brief: Number of file handles for the TrafficController’s process.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Linux File Descriptor
+
+Number of file handles for the TrafficController’s process.

--- a/cloudfoundry/docs/LoggregatorTrafficController.Uptime.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.Uptime.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Uptime
+brief: Uptime for the Traffic Controller’s process. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Uptime
+
+Uptime for the Traffic Controller’s process. Emitted every 30 seconds.

--- a/cloudfoundry/docs/LoggregatorTrafficController.dopplerProxy.containermetricsLatency.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.dopplerProxy.containermetricsLatency.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Doppler Proxy Containermetrics Latency
+brief: Duration for serving container metrics via the containermetrics endpoint (milliseconds). Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Doppler Proxy Containermetrics Latency
+
+Duration for serving container metrics via the containermetrics endpoint (milliseconds). Emitted every 30 seconds.

--- a/cloudfoundry/docs/LoggregatorTrafficController.dopplerProxy.recentlogsLatency.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.dopplerProxy.recentlogsLatency.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Doppler Proxy Recentlogs Latency
+brief: Duration for serving recent logs via the recentLogs endpoint (milliseconds). Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Doppler Proxy Recentlogs Latency
+
+Duration for serving recent logs via the recentLogs endpoint (milliseconds). Emitted every 30 seconds.

--- a/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Memory Stats Last GC Pause Time NS
+brief: Duration of the last Garbage Collector pause in nanoseconds.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Memory Stats Last GC Pause Time NS
+
+Duration of the last Garbage Collector pause in nanoseconds.

--- a/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/LoggregatorTrafficController.numCPUS.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/LoggregatorTrafficController.numGoRoutines.md
+++ b/cloudfoundry/docs/LoggregatorTrafficController.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Loggregator Traffic Controller Num Go Routines
+brief: Instantaneous number of active goroutines in the Doppler process.
+metric_type: gauge
+---
+
+### Loggregator Traffic Controller Num Go Routines
+
+Instantaneous number of active goroutines in the Doppler process.

--- a/cloudfoundry/docs/MetronAgent.DopplerForwarder.sentMessages.md
+++ b/cloudfoundry/docs/MetronAgent.DopplerForwarder.sentMessages.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Doppler Forwarder Sent Messages
+brief: Lifetime number of messages sent to Doppler regardless of protocol. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Doppler Forwarder Sent Messages
+
+Lifetime number of messages sent to Doppler regardless of protocol. Emitted every 30 seconds.

--- a/cloudfoundry/docs/MetronAgent.MessageAggregator.counterEventReceived.md
+++ b/cloudfoundry/docs/MetronAgent.MessageAggregator.counterEventReceived.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Message Aggregator Counter Event Received
+brief: Lifetime number of CounterEvents aggregated in Metron.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Message Aggregator Counter Event Received
+
+Lifetime number of CounterEvents aggregated in Metron.

--- a/cloudfoundry/docs/MetronAgent.MessageBuffer.droppedMessageCount.md
+++ b/cloudfoundry/docs/MetronAgent.MessageBuffer.droppedMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Message Buffer Dropped Message Count
+brief: Lifetime number of intentionally dropped messages from Metron’s batch writer buffer. Batch writing is performed over TCP/TLS only.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Message Buffer Dropped Message Count
+
+Lifetime number of intentionally dropped messages from Metron’s batch writer buffer. Batch writing is performed over TCP/TLS only.

--- a/cloudfoundry/docs/MetronAgent.dropsondeAgentListener.currentBufferCount.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeAgentListener.currentBufferCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Agent Listener Current Buffer Count
+brief: Instantaneous number of Dropsonde messages read by UDP socket  but not yet unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Agent Listener Current Buffer Count
+
+Instantaneous number of Dropsonde messages read by UDP socket  but not yet unmarshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeAgentListener.receivedByteCount.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeAgentListener.receivedByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Agent Listener Received Byte Count
+brief: Lifetime number of bytes of Dropsonde messages read by UDP socket.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Agent Listener Received Byte Count
+
+Lifetime number of bytes of Dropsonde messages read by UDP socket.

--- a/cloudfoundry/docs/MetronAgent.dropsondeAgentListener.receivedMessageCount.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeAgentListener.receivedMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Agent Listener Received Message Count
+brief: Lifetime number of Dropsonde messages read by UDP socket.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Agent Listener Received Message Count
+
+Lifetime number of Dropsonde messages read by UDP socket.

--- a/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.containerMetricMarshalled.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.containerMetricMarshalled.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Marshaller Container Metric Marshalled
+brief: Lifetime number of ContainerMetric messages marshalled.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Marshaller Container Metric Marshalled
+
+Lifetime number of ContainerMetric messages marshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.counterEventMarshalled.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.counterEventMarshalled.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Marshaller Counter Event Marshalled
+brief: Lifetime number of CounterEvent messages marshalled.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Marshaller Counter Event Marshalled
+
+Lifetime number of CounterEvent messages marshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.errorMarshalled.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.errorMarshalled.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Marshaller Error Marshalled
+brief: Lifetime number of Error messages marshalled.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Marshaller Error Marshalled
+
+Lifetime number of Error messages marshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.heartbeatMarshalled.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.heartbeatMarshalled.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Marshaller Heartbeat Marshalled
+brief: Lifetime number of Heartbeat messages marshalled.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Marshaller Heartbeat Marshalled
+
+Lifetime number of Heartbeat messages marshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.httpStartStopMarshalled.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.httpStartStopMarshalled.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Marshaller HTTP Start Stop Marshalled
+brief: Lifetime number of HttpStartStop messages marshalled.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Marshaller HTTP Start Stop Marshalled
+
+Lifetime number of HttpStartStop messages marshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.logMessageMarshalled.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.logMessageMarshalled.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Marshaller Log Message Marshalled
+brief: Lifetime number of LogMessage messages marshalled.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Marshaller Log Message Marshalled
+
+Lifetime number of LogMessage messages marshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.marshalErrors.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.marshalErrors.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Marshaller Marshal Errors
+brief: Lifetime number of errors when marshalling messages.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Marshaller Marshal Errors
+
+Lifetime number of errors when marshalling messages.

--- a/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.valueMetricMarshalled.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeMarshaller.valueMetricMarshalled.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Marshaller Value Metric Marshalled
+brief: Lifetime number of ValueMetric messages marshalled.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Marshaller Value Metric Marshalled
+
+Lifetime number of ValueMetric messages marshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.containerMetricReceived.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.containerMetricReceived.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Unmarshaller Container Metric Received
+brief: Lifetime number of ContainerMetric messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Unmarshaller Container Metric Received
+
+Lifetime number of ContainerMetric messages unmarshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.counterEventReceived.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.counterEventReceived.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Unmarshaller Counter Event Received
+brief: Lifetime number of CounterEvent messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Unmarshaller Counter Event Received
+
+Lifetime number of CounterEvent messages unmarshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.errorReceived.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.errorReceived.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Unmarshaller Error Received
+brief: Lifetime number of Error messages unmarshalled.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Unmarshaller Error Received
+
+Lifetime number of Error messages unmarshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.heartbeatReceived.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.heartbeatReceived.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Unmarshaller Heartbeat Received
+brief: DEPRECATED
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Unmarshaller Heartbeat Received
+
+DEPRECATED

--- a/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.httpStartStopReceived.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.httpStartStopReceived.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Unmarshaller HTTP Start Stop Received
+brief: Lifetime number of HttpStartStop messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Unmarshaller HTTP Start Stop Received
+
+Lifetime number of HttpStartStop messages unmarshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.logMessageTotal.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.logMessageTotal.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Unmarshaller Log Message Total
+brief: Lifetime number of LogMessage messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Unmarshaller Log Message Total
+
+Lifetime number of LogMessage messages unmarshalled.

--- a/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.unmarshalErrors.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.unmarshalErrors.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Unmarshaller Unmarshal Errors
+brief: Lifetime number of errors when unmarshalling messages.
+metric_type: gauge
+---
+
+### Metron Agent Dropsonde Unmarshaller Unmarshal Errors
+
+Lifetime number of errors when unmarshalling messages.

--- a/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.valueMetricReceived.md
+++ b/cloudfoundry/docs/MetronAgent.dropsondeUnmarshaller.valueMetricReceived.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Dropsonde Unmarshaller Value Metric Received
+brief: Lifetime number of ValueMetric messages unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Dropsonde Unmarshaller Value Metric Received
+
+Lifetime number of ValueMetric messages unmarshalled.

--- a/cloudfoundry/docs/MetronAgent.legacyAgentListener.currentBufferCount.md
+++ b/cloudfoundry/docs/MetronAgent.legacyAgentListener.currentBufferCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Legacy Agent Listener Current Buffer Count
+brief: Instantaneous number of Legacy messages read by UDP socket but not yet unmarshalled.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Legacy Agent Listener Current Buffer Count
+
+Instantaneous number of Legacy messages read by UDP socket but not yet unmarshalled.

--- a/cloudfoundry/docs/MetronAgent.legacyAgentListener.receivedByteCount.md
+++ b/cloudfoundry/docs/MetronAgent.legacyAgentListener.receivedByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Legacy Agent Listener Received Byte Count
+brief: Lifetime number of bytes of Legacy messages read by UDP socket.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Legacy Agent Listener Received Byte Count
+
+Lifetime number of bytes of Legacy messages read by UDP socket.

--- a/cloudfoundry/docs/MetronAgent.legacyAgentListener.receivedMessageCount.md
+++ b/cloudfoundry/docs/MetronAgent.legacyAgentListener.receivedMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Legacy Agent Listener Received Message Count
+brief: Lifetime number of Legacy messages read by UDP socket.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Legacy Agent Listener Received Message Count
+
+Lifetime number of Legacy messages read by UDP socket.

--- a/cloudfoundry/docs/MetronAgent.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/MetronAgent.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Memory Stats Last GC Pause Time NS
+brief: Duration of the last Garbage Collector pause in nanoseconds.
+metric_type: gauge
+---
+
+### Metron Agent Memory Stats Last GC Pause Time NS
+
+Duration of the last Garbage Collector pause in nanoseconds.

--- a/cloudfoundry/docs/MetronAgent.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/MetronAgent.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Metron Agent Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/MetronAgent.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/MetronAgent.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Metron Agent Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/MetronAgent.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/MetronAgent.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Metron Agent Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/MetronAgent.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/MetronAgent.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Metron Agent Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/MetronAgent.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/MetronAgent.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Metron Agent Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/MetronAgent.numCpus.md
+++ b/cloudfoundry/docs/MetronAgent.numCpus.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Num Cpus
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Metron Agent Num Cpus
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/MetronAgent.numGoRoutines.md
+++ b/cloudfoundry/docs/MetronAgent.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Num Go Routines
+brief: Instantaneous number of active goroutines in the Doppler process.
+metric_type: gauge
+---
+
+### Metron Agent Num Go Routines
+
+Instantaneous number of active goroutines in the Doppler process.

--- a/cloudfoundry/docs/MetronAgent.tcp.sendErrorCount.md
+++ b/cloudfoundry/docs/MetronAgent.tcp.sendErrorCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent TCP Send Error Count
+brief: Lifetime number of errors if writing to Doppler over TCP fails.
+metric_type: cumulative_counter
+---
+
+### Metron Agent TCP Send Error Count
+
+Lifetime number of errors if writing to Doppler over TCP fails.

--- a/cloudfoundry/docs/MetronAgent.tcp.sentByteCount.md
+++ b/cloudfoundry/docs/MetronAgent.tcp.sentByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent TCP Sent Byte Count
+brief: Lifetime number of sent bytes to Doppler over TCP.
+metric_type: cumulative_counter
+---
+
+### Metron Agent TCP Sent Byte Count
+
+Lifetime number of sent bytes to Doppler over TCP.

--- a/cloudfoundry/docs/MetronAgent.tcp.sentMessageCount.md
+++ b/cloudfoundry/docs/MetronAgent.tcp.sentMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent TCP Sent Message Count
+brief: Lifetime number of sent messages to Doppler over TCP.
+metric_type: cumulative_counter
+---
+
+### Metron Agent TCP Sent Message Count
+
+Lifetime number of sent messages to Doppler over TCP.

--- a/cloudfoundry/docs/MetronAgent.tls.sendErrorCount.md
+++ b/cloudfoundry/docs/MetronAgent.tls.sendErrorCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Tls Send Error Count
+brief: Lifetime number of errors if writing to Doppler over TLS fails.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Tls Send Error Count
+
+Lifetime number of errors if writing to Doppler over TLS fails.

--- a/cloudfoundry/docs/MetronAgent.tls.sentByteCount.md
+++ b/cloudfoundry/docs/MetronAgent.tls.sentByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Tls Sent Byte Count
+brief: Lifetime number of sent bytes to Doppler over TLS. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Tls Sent Byte Count
+
+Lifetime number of sent bytes to Doppler over TLS. Emitted every 30 seconds.

--- a/cloudfoundry/docs/MetronAgent.tls.sentMessageCount.md
+++ b/cloudfoundry/docs/MetronAgent.tls.sentMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent Tls Sent Message Count
+brief: Lifetime number of sent messages to Doppler over TLS. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Metron Agent Tls Sent Message Count
+
+Lifetime number of sent messages to Doppler over TLS. Emitted every 30 seconds.

--- a/cloudfoundry/docs/MetronAgent.udp.sendErrorCount.md
+++ b/cloudfoundry/docs/MetronAgent.udp.sendErrorCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent UDP Send Error Count
+brief: Lifetime number of errors if writing to Doppler over UDP fails.
+metric_type: cumulative_counter
+---
+
+### Metron Agent UDP Send Error Count
+
+Lifetime number of errors if writing to Doppler over UDP fails.

--- a/cloudfoundry/docs/MetronAgent.udp.sentByteCount.md
+++ b/cloudfoundry/docs/MetronAgent.udp.sentByteCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent UDP Sent Byte Count
+brief: Lifetime number of sent bytes to Doppler over UDP.
+metric_type: cumulative_counter
+---
+
+### Metron Agent UDP Sent Byte Count
+
+Lifetime number of sent bytes to Doppler over UDP.

--- a/cloudfoundry/docs/MetronAgent.udp.sentMessageCount.md
+++ b/cloudfoundry/docs/MetronAgent.udp.sentMessageCount.md
@@ -1,0 +1,9 @@
+---
+title: Metron Agent UDP Sent Message Count
+brief: Lifetime number of sent messages to Doppler over UDP.
+metric_type: cumulative_counter
+---
+
+### Metron Agent UDP Sent Message Count
+
+Lifetime number of sent messages to Doppler over UDP.

--- a/cloudfoundry/docs/auctioneer.AuctioneerFetchStatesDuration.md
+++ b/cloudfoundry/docs/auctioneer.AuctioneerFetchStatesDuration.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Auctioneer Fetch States Duration
+brief: Time in nanoseconds that the auctioneer took to fetch state from all the cells when running its auction. Emitted every 30 seconds during each auction.
+metric_type: gauge
+---
+
+### Auctioneer Auctioneer Fetch States Duration
+
+Time in nanoseconds that the auctioneer took to fetch state from all the cells when running its auction. Emitted every 30 seconds during each auction.

--- a/cloudfoundry/docs/auctioneer.AuctioneerLRPAuctionsFailed.md
+++ b/cloudfoundry/docs/auctioneer.AuctioneerLRPAuctionsFailed.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Auctioneer LRP Auctions Failed
+brief: Cumulative number of LRP instances that the auctioneer failed to place on Diego cells. Emitted every 30 seconds during each auction.
+metric_type: cumulative_counter
+---
+
+### Auctioneer Auctioneer LRP Auctions Failed
+
+Cumulative number of LRP instances that the auctioneer failed to place on Diego cells. Emitted every 30 seconds during each auction.

--- a/cloudfoundry/docs/auctioneer.AuctioneerLRPAuctionsStarted.md
+++ b/cloudfoundry/docs/auctioneer.AuctioneerLRPAuctionsStarted.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Auctioneer LRP Auctions Started
+brief: Cumulative number of LRP instances that the auctioneer successfully placed on Diego cells. Emitted every 30 seconds during each auction.
+metric_type: cumulative_counter
+---
+
+### Auctioneer Auctioneer LRP Auctions Started
+
+Cumulative number of LRP instances that the auctioneer successfully placed on Diego cells. Emitted every 30 seconds during each auction.

--- a/cloudfoundry/docs/auctioneer.AuctioneerTaskAuctionsFailed.md
+++ b/cloudfoundry/docs/auctioneer.AuctioneerTaskAuctionsFailed.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Auctioneer Task Auctions Failed
+brief: Cumulative number of Tasks that the auctioneer failed to place on Diego cells. Emitted every 30 seconds during each auction.
+metric_type: cumulative_counter
+---
+
+### Auctioneer Auctioneer Task Auctions Failed
+
+Cumulative number of Tasks that the auctioneer failed to place on Diego cells. Emitted every 30 seconds during each auction.

--- a/cloudfoundry/docs/auctioneer.AuctioneerTaskAuctionsStarted.md
+++ b/cloudfoundry/docs/auctioneer.AuctioneerTaskAuctionsStarted.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Auctioneer Task Auctions Started
+brief: Cumulative number of Tasks that the auctioneer successfully placed on Diego cells. Emitted every 30 seconds during each auction.
+metric_type: cumulative_counter
+---
+
+### Auctioneer Auctioneer Task Auctions Started
+
+Cumulative number of Tasks that the auctioneer successfully placed on Diego cells. Emitted every 30 seconds during each auction.

--- a/cloudfoundry/docs/auctioneer.LockHeld.v1-locks-auctioneer_lock.md
+++ b/cloudfoundry/docs/auctioneer.LockHeld.v1-locks-auctioneer_lock.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Lock Held V1-Locks-Auctioneer Lock
+brief: Whether an auctioneer holds the auctioneer lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active auctioneer.
+metric_type: gauge
+---
+
+### Auctioneer Lock Held V1-Locks-Auctioneer Lock
+
+Whether an auctioneer holds the auctioneer lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active auctioneer.

--- a/cloudfoundry/docs/auctioneer.LockHeldDuration.v1-locks-auctioneer_lock.md
+++ b/cloudfoundry/docs/auctioneer.LockHeldDuration.v1-locks-auctioneer_lock.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Lock Held Duration V1-Locks-Auctioneer Lock
+brief: Time in nanoseconds that the active auctioneer has held the auctioneer lock. Emitted every 30 seconds by the active auctioneer.
+metric_type: gauge
+---
+
+### Auctioneer Lock Held Duration V1-Locks-Auctioneer Lock
+
+Time in nanoseconds that the active auctioneer has held the auctioneer lock. Emitted every 30 seconds by the active auctioneer.

--- a/cloudfoundry/docs/auctioneer.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/auctioneer.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### Auctioneer Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/auctioneer.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/auctioneer.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Auctioneer Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/auctioneer.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/auctioneer.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Auctioneer Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/auctioneer.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/auctioneer.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Auctioneer Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/auctioneer.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/auctioneer.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Auctioneer Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/auctioneer.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/auctioneer.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Auctioneer Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/auctioneer.numCPUS.md
+++ b/cloudfoundry/docs/auctioneer.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Auctioneer Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/auctioneer.numGoRoutines.md
+++ b/cloudfoundry/docs/auctioneer.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Auctioneer Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### Auctioneer Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/bbs.BBSMasterElected.md
+++ b/cloudfoundry/docs/bbs.BBSMasterElected.md
@@ -1,0 +1,9 @@
+---
+title: BBS BBS Master Elected
+brief: Emitted once when the BBS is elected as master.
+metric_type: gauge
+---
+
+### BBS BBS Master Elected
+
+Emitted once when the BBS is elected as master.

--- a/cloudfoundry/docs/bbs.ConvergenceLRPDuration.md
+++ b/cloudfoundry/docs/bbs.ConvergenceLRPDuration.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence LRP Duration
+brief: Time in nanoseconds that the BBS took to run its LRP convergence pass. Emitted every 30 seconds when LRP convergence runs.
+metric_type: gauge
+---
+
+### BBS Convergence LRP Duration
+
+Time in nanoseconds that the BBS took to run its LRP convergence pass. Emitted every 30 seconds when LRP convergence runs.

--- a/cloudfoundry/docs/bbs.ConvergenceLRPPreProcessingActualLRPsDeleted.md
+++ b/cloudfoundry/docs/bbs.ConvergenceLRPPreProcessingActualLRPsDeleted.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence LRP Pre Processing Actual LR Ps Deleted
+brief: Cumulative number of times the BBS has detected and deleted a malformed ActualLRP in its LRP convergence pass. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Convergence LRP Pre Processing Actual LR Ps Deleted
+
+Cumulative number of times the BBS has detected and deleted a malformed ActualLRP in its LRP convergence pass. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ConvergenceLRPPreProcessingMalformedRunInfos.md
+++ b/cloudfoundry/docs/bbs.ConvergenceLRPPreProcessingMalformedRunInfos.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence LRP Pre Processing Malformed Run Infos
+brief: Cumulative number of times the BBS has detected a malformed DesiredLRP RunInfo in its LRP convergence pass. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Convergence LRP Pre Processing Malformed Run Infos
+
+Cumulative number of times the BBS has detected a malformed DesiredLRP RunInfo in its LRP convergence pass. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ConvergenceLRPPreProcessingMalformedSchedulingInfos.md
+++ b/cloudfoundry/docs/bbs.ConvergenceLRPPreProcessingMalformedSchedulingInfos.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence LRP Pre Processing Malformed Scheduling Infos
+brief: Cumulative number of times the BBS has detected a malformed DesiredLRP SchedulingInfo in its LRP convergence pass. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Convergence LRP Pre Processing Malformed Scheduling Infos
+
+Cumulative number of times the BBS has detected a malformed DesiredLRP SchedulingInfo in its LRP convergence pass. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ConvergenceLRPRuns.md
+++ b/cloudfoundry/docs/bbs.ConvergenceLRPRuns.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence LRP Runs
+brief: Cumulative number of times BBS has run its LRP convergence pass. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### BBS Convergence LRP Runs
+
+Cumulative number of times BBS has run its LRP convergence pass. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ConvergenceTaskDuration.md
+++ b/cloudfoundry/docs/bbs.ConvergenceTaskDuration.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence Task Duration
+brief: Time in nanoseconds that the BBS took to run its Task convergence pass. Emitted every 30 seconds when Task convergence runs.
+metric_type: gauge
+---
+
+### BBS Convergence Task Duration
+
+Time in nanoseconds that the BBS took to run its Task convergence pass. Emitted every 30 seconds when Task convergence runs.

--- a/cloudfoundry/docs/bbs.ConvergenceTaskRuns.md
+++ b/cloudfoundry/docs/bbs.ConvergenceTaskRuns.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence Task Runs
+brief: Cumulative number of times the BBS has run its Task convergence pass. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### BBS Convergence Task Runs
+
+Cumulative number of times the BBS has run its Task convergence pass. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ConvergenceTasksKicked.md
+++ b/cloudfoundry/docs/bbs.ConvergenceTasksKicked.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence Tasks Kicked
+brief: Cumulative number of times the BBS has updated a Task during its Task convergence pass. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### BBS Convergence Tasks Kicked
+
+Cumulative number of times the BBS has updated a Task during its Task convergence pass. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ConvergenceTasksPruned.md
+++ b/cloudfoundry/docs/bbs.ConvergenceTasksPruned.md
@@ -1,0 +1,9 @@
+---
+title: BBS Convergence Tasks Pruned
+brief: Cumulative number of times the BBS has deleted a malformed Task during its Task convergence pass. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### BBS Convergence Tasks Pruned
+
+Cumulative number of times the BBS has deleted a malformed Task during its Task convergence pass. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.CrashedActualLRPs.md
+++ b/cloudfoundry/docs/bbs.CrashedActualLRPs.md
@@ -1,0 +1,9 @@
+---
+title: BBS Crashed Actual LR Ps
+brief: Total number of LRP instances that have crashed. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Crashed Actual LR Ps
+
+Total number of LRP instances that have crashed. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.CrashingDesiredLRPs.md
+++ b/cloudfoundry/docs/bbs.CrashingDesiredLRPs.md
@@ -1,0 +1,9 @@
+---
+title: BBS Crashing Desired LR Ps
+brief: Total number of DesiredLRPs that have at least one crashed instance. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Crashing Desired LR Ps
+
+Total number of DesiredLRPs that have at least one crashed instance. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.Domain.cf-apps.md
+++ b/cloudfoundry/docs/bbs.Domain.cf-apps.md
@@ -1,0 +1,9 @@
+---
+title: BBS Domain Cf-Apps
+brief: Whether the ‘cf-apps’ domain is up-to-date, so that CF apps from CC have been synchronized with DesiredLRPs for Diego to run. 1 means the domain is up-to-date, no data means it is not. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Domain Cf-Apps
+
+Whether the ‘cf-apps’ domain is up-to-date, so that CF apps from CC have been synchronized with DesiredLRPs for Diego to run. 1 means the domain is up-to-date, no data means it is not. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.Domain.cf-tasks.md
+++ b/cloudfoundry/docs/bbs.Domain.cf-tasks.md
@@ -1,0 +1,9 @@
+---
+title: BBS Domain Cf-Tasks
+brief: Whether the ‘cf-tasks’ domain is up-to-date, so that CF tasks from CC have been synchronized with tasks for Diego to run. 1 means the domain is up-to-date, no data means it is not. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Domain Cf-Tasks
+
+Whether the ‘cf-tasks’ domain is up-to-date, so that CF tasks from CC have been synchronized with tasks for Diego to run. 1 means the domain is up-to-date, no data means it is not. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ETCDLeader.md
+++ b/cloudfoundry/docs/bbs.ETCDLeader.md
@@ -1,0 +1,9 @@
+---
+title: BBS ETCD Leader
+brief: Index of the leader node in the etcd cluster. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS ETCD Leader
+
+Index of the leader node in the etcd cluster. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ETCDRaftTerm.md
+++ b/cloudfoundry/docs/bbs.ETCDRaftTerm.md
@@ -1,0 +1,9 @@
+---
+title: BBS ETCD Raft Term
+brief: Raft term of the etcd cluster. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS ETCD Raft Term
+
+Raft term of the etcd cluster. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ETCDReceivedBandwidthRate.md
+++ b/cloudfoundry/docs/bbs.ETCDReceivedBandwidthRate.md
@@ -1,0 +1,9 @@
+---
+title: BBS ETCD Received Bandwidth Rate
+brief: Number of bytes per second received by the follower etcd node. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS ETCD Received Bandwidth Rate
+
+Number of bytes per second received by the follower etcd node. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ETCDReceivedRequestRate.md
+++ b/cloudfoundry/docs/bbs.ETCDReceivedRequestRate.md
@@ -1,0 +1,9 @@
+---
+title: BBS ETCD Received Request Rate
+brief: Number of requests per second received by the follower etcd node. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS ETCD Received Request Rate
+
+Number of requests per second received by the follower etcd node. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ETCDSentBandwidthRate.md
+++ b/cloudfoundry/docs/bbs.ETCDSentBandwidthRate.md
@@ -1,0 +1,9 @@
+---
+title: BBS ETCD Sent Bandwidth Rate
+brief: Number of bytes per second sent by the leader etcd node. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS ETCD Sent Bandwidth Rate
+
+Number of bytes per second sent by the leader etcd node. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ETCDSentRequestRate.md
+++ b/cloudfoundry/docs/bbs.ETCDSentRequestRate.md
@@ -1,0 +1,9 @@
+---
+title: BBS ETCD Sent Request Rate
+brief: Number of requests per second sent by the leader etcd node. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS ETCD Sent Request Rate
+
+Number of requests per second sent by the leader etcd node. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.ETCDWatchers.md
+++ b/cloudfoundry/docs/bbs.ETCDWatchers.md
@@ -1,0 +1,9 @@
+---
+title: BBS ETCD Watchers
+brief: Number of watches set against the etcd cluster. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS ETCD Watchers
+
+Number of watches set against the etcd cluster. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.LRPsClaimed.md
+++ b/cloudfoundry/docs/bbs.LRPsClaimed.md
@@ -1,0 +1,9 @@
+---
+title: BBS LR Ps Claimed
+brief: Total number of LRP instances that have been claimed by some cell. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS LR Ps Claimed
+
+Total number of LRP instances that have been claimed by some cell. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.LRPsDesired.md
+++ b/cloudfoundry/docs/bbs.LRPsDesired.md
@@ -1,0 +1,9 @@
+---
+title: BBS LR Ps Desired
+brief: Total number of LRP instances desired across all LRPs. Emitted periodically.
+metric_type: gauge
+---
+
+### BBS LR Ps Desired
+
+Total number of LRP instances desired across all LRPs. Emitted periodically.

--- a/cloudfoundry/docs/bbs.LRPsExtra.md
+++ b/cloudfoundry/docs/bbs.LRPsExtra.md
@@ -1,0 +1,9 @@
+---
+title: BBS LR Ps Extra
+brief: Total number of LRP instances that are no longer desired but still have a BBS record. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS LR Ps Extra
+
+Total number of LRP instances that are no longer desired but still have a BBS record. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.LRPsMissing.md
+++ b/cloudfoundry/docs/bbs.LRPsMissing.md
@@ -1,0 +1,9 @@
+---
+title: BBS LR Ps Missing
+brief: Total number of LRP instances that are desired but have no record in the BBS. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS LR Ps Missing
+
+Total number of LRP instances that are desired but have no record in the BBS. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.LRPsRunning.md
+++ b/cloudfoundry/docs/bbs.LRPsRunning.md
@@ -1,0 +1,9 @@
+---
+title: BBS LR Ps Running
+brief: Total number of LRP instances that are running on cells. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS LR Ps Running
+
+Total number of LRP instances that are running on cells. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.LRPsUnclaimed.md
+++ b/cloudfoundry/docs/bbs.LRPsUnclaimed.md
@@ -1,0 +1,9 @@
+---
+title: BBS LR Ps Unclaimed
+brief: Total number of LRP instances that have not yet been claimed by a cell. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS LR Ps Unclaimed
+
+Total number of LRP instances that have not yet been claimed by a cell. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.LockHeld.v1-locks-bbs_lock.md
+++ b/cloudfoundry/docs/bbs.LockHeld.v1-locks-bbs_lock.md
@@ -1,0 +1,9 @@
+---
+title: BBS Lock Held V1-Locks-BBS Lock
+brief: Whether a BBS holds the BBS lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active BBS server.
+metric_type: gauge
+---
+
+### BBS Lock Held V1-Locks-BBS Lock
+
+Whether a BBS holds the BBS lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active BBS server.

--- a/cloudfoundry/docs/bbs.LockHeldDuration.v1-locks-bbs_lock.md
+++ b/cloudfoundry/docs/bbs.LockHeldDuration.v1-locks-bbs_lock.md
@@ -1,0 +1,9 @@
+---
+title: BBS Lock Held Duration V1-Locks-BBS Lock
+brief: Time in nanoseconds that the active BBS has held the BBS lock. Emitted every 30 seconds by the active BBS server.
+metric_type: gauge
+---
+
+### BBS Lock Held Duration V1-Locks-BBS Lock
+
+Time in nanoseconds that the active BBS has held the BBS lock. Emitted every 30 seconds by the active BBS server.

--- a/cloudfoundry/docs/bbs.MetricsReportingDuration.md
+++ b/cloudfoundry/docs/bbs.MetricsReportingDuration.md
@@ -1,0 +1,9 @@
+---
+title: BBS Metrics Reporting Duration
+brief: Time in nanoseconds that the BBS took to emit metrics about etcd. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Metrics Reporting Duration
+
+Time in nanoseconds that the BBS took to emit metrics about etcd. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.MigrationDuration.md
+++ b/cloudfoundry/docs/bbs.MigrationDuration.md
@@ -1,0 +1,9 @@
+---
+title: BBS Migration Duration
+brief: Time in nanoseconds that the BBS took to run migrations against its persistence store. Emitted each time a BBS becomes the active master.
+metric_type: gauge
+---
+
+### BBS Migration Duration
+
+Time in nanoseconds that the BBS took to run migrations against its persistence store. Emitted each time a BBS becomes the active master.

--- a/cloudfoundry/docs/bbs.RequestCount.md
+++ b/cloudfoundry/docs/bbs.RequestCount.md
@@ -1,0 +1,9 @@
+---
+title: BBS Request Count
+brief: Cumulative number of requests the BBS has handled through its API. Emitted for each BBS request.
+metric_type: cumulative_counter
+---
+
+### BBS Request Count
+
+Cumulative number of requests the BBS has handled through its API. Emitted for each BBS request.

--- a/cloudfoundry/docs/bbs.RequestLatency.md
+++ b/cloudfoundry/docs/bbs.RequestLatency.md
@@ -1,0 +1,9 @@
+---
+title: BBS Request Latency
+brief: Time in nanoseconds that the BBS took to handle requests to its API endpoints. Emitted when the BBS API handles requests.
+metric_type: gauge
+---
+
+### BBS Request Latency
+
+Time in nanoseconds that the BBS took to handle requests to its API endpoints. Emitted when the BBS API handles requests.

--- a/cloudfoundry/docs/bbs.TasksCompleted.md
+++ b/cloudfoundry/docs/bbs.TasksCompleted.md
@@ -1,0 +1,9 @@
+---
+title: BBS Tasks Completed
+brief: Total number of Tasks that have completed. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Tasks Completed
+
+Total number of Tasks that have completed. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.TasksPending.md
+++ b/cloudfoundry/docs/bbs.TasksPending.md
@@ -1,0 +1,9 @@
+---
+title: BBS Tasks Pending
+brief: Total number of Tasks that have not yet been placed on a cell. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Tasks Pending
+
+Total number of Tasks that have not yet been placed on a cell. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.TasksResolving.md
+++ b/cloudfoundry/docs/bbs.TasksResolving.md
@@ -1,0 +1,9 @@
+---
+title: BBS Tasks Resolving
+brief: Total number of Tasks locked for deletion. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Tasks Resolving
+
+Total number of Tasks locked for deletion. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.TasksRunning.md
+++ b/cloudfoundry/docs/bbs.TasksRunning.md
@@ -1,0 +1,9 @@
+---
+title: BBS Tasks Running
+brief: Total number of Tasks running on cells. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### BBS Tasks Running
+
+Total number of Tasks running on cells. Emitted every 30 seconds.

--- a/cloudfoundry/docs/bbs.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/bbs.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: BBS Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### BBS Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/bbs.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/bbs.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: BBS Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### BBS Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/bbs.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/bbs.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: BBS Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### BBS Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/bbs.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/bbs.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: BBS Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### BBS Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/bbs.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/bbs.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: BBS Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### BBS Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/bbs.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/bbs.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: BBS Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### BBS Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/bbs.numCPUS.md
+++ b/cloudfoundry/docs/bbs.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: BBS Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### BBS Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/bbs.numGoRoutines.md
+++ b/cloudfoundry/docs/bbs.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: BBS Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### BBS Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/cc.failed_job_count.<VM_NAME>-<VM_INDEX>.md
+++ b/cloudfoundry/docs/cc.failed_job_count.<VM_NAME>-<VM_INDEX>.md
@@ -1,0 +1,9 @@
+---
+title: CC Failed Job Count <VM NAME>-<VM INDEX>
+brief: Number of failed jobs in the <VM_NAME>-<VM_INDEX> queue. This is the number of delayed jobs where the failed at column is populated with the time of the most recently failed attempt at the job. The failed job count is not specific to the jobs run by the Cloud Controller worker. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
+metric_type: cumulative_counter
+---
+
+### CC Failed Job Count <VM NAME>-<VM INDEX>
+
+Number of failed jobs in the <VM_NAME>-<VM_INDEX> queue. This is the number of delayed jobs where the failed at column is populated with the time of the most recently failed attempt at the job. The failed job count is not specific to the jobs run by the Cloud Controller worker. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.failed_job_count.cc-generic.md
+++ b/cloudfoundry/docs/cc.failed_job_count.cc-generic.md
@@ -1,0 +1,9 @@
+---
+title: CC Failed Job Count CC-Generic
+brief: Number of failed jobs in the cc-generic queue. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
+metric_type: cumulative_counter
+---
+
+### CC Failed Job Count CC-Generic
+
+Number of failed jobs in the cc-generic queue. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.failed_job_count.total.md
+++ b/cloudfoundry/docs/cc.failed_job_count.total.md
@@ -1,0 +1,9 @@
+---
+title: CC Failed Job Count Total
+brief: Number of failed jobs in all queues. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Failed Job Count Total
+
+Number of failed jobs in all queues. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.http_status.1XX.md
+++ b/cloudfoundry/docs/cc.http_status.1XX.md
@@ -1,0 +1,9 @@
+---
+title: CC HTTP Status 1XX
+brief: Number of HTTP response status codes of type 1xx (informational). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle.
+metric_type: cumulative_counter
+---
+
+### CC HTTP Status 1XX
+
+Number of HTTP response status codes of type 1xx (informational). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle.

--- a/cloudfoundry/docs/cc.http_status.2XX.md
+++ b/cloudfoundry/docs/cc.http_status.2XX.md
@@ -1,0 +1,9 @@
+---
+title: CC HTTP Status 2XX
+brief: Number of HTTP response status codes of type 2xx (success). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle. Emitted for each Cloud Controller request.
+metric_type: cumulative_counter
+---
+
+### CC HTTP Status 2XX
+
+Number of HTTP response status codes of type 2xx (success). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle. Emitted for each Cloud Controller request.

--- a/cloudfoundry/docs/cc.http_status.3XX.md
+++ b/cloudfoundry/docs/cc.http_status.3XX.md
@@ -1,0 +1,9 @@
+---
+title: CC HTTP Status 3XX
+brief: Number of HTTP response status codes of type 3xx (redirection). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle. Emitted for each Cloud Controller request.
+metric_type: cumulative_counter
+---
+
+### CC HTTP Status 3XX
+
+Number of HTTP response status codes of type 3xx (redirection). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle. Emitted for each Cloud Controller request.

--- a/cloudfoundry/docs/cc.http_status.4XX.md
+++ b/cloudfoundry/docs/cc.http_status.4XX.md
@@ -1,0 +1,9 @@
+---
+title: CC HTTP Status 4XX
+brief: Number of HTTP response status codes of type 4xx (client error). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle. Emitted for each Cloud Controller request.
+metric_type: cumulative_counter
+---
+
+### CC HTTP Status 4XX
+
+Number of HTTP response status codes of type 4xx (client error). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle. Emitted for each Cloud Controller request.

--- a/cloudfoundry/docs/cc.http_status.5XX.md
+++ b/cloudfoundry/docs/cc.http_status.5XX.md
@@ -1,0 +1,9 @@
+---
+title: CC HTTP Status 5XX
+brief: Number of HTTP response status codes of type 5xx (server error). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle.
+metric_type: cumulative_counter
+---
+
+### CC HTTP Status 5XX
+
+Number of HTTP response status codes of type 5xx (server error). This resets when the Cloud Controller process is restarted and is incremented at the end of each request cycle.

--- a/cloudfoundry/docs/cc.job_queue_length.cc-<VM_NAME>-<VM_INDEX>.md
+++ b/cloudfoundry/docs/cc.job_queue_length.cc-<VM_NAME>-<VM_INDEX>.md
@@ -1,0 +1,9 @@
+---
+title: CC Job Queue Length CC-<VM NAME>-<VM INDEX>
+brief: Number of background jobs in the <VM_NAME>-<VM_INDEX> queue that have yet to run for the first time. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Job Queue Length CC-<VM NAME>-<VM INDEX>
+
+Number of background jobs in the <VM_NAME>-<VM_INDEX> queue that have yet to run for the first time. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.job_queue_length.cc-generic.md
+++ b/cloudfoundry/docs/cc.job_queue_length.cc-generic.md
@@ -1,0 +1,9 @@
+---
+title: CC Job Queue Length CC-Generic
+brief: Number of background jobs in the cc-generic queue that have yet to run for the first time. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Job Queue Length CC-Generic
+
+Number of background jobs in the cc-generic queue that have yet to run for the first time. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.job_queue_length.total.md
+++ b/cloudfoundry/docs/cc.job_queue_length.total.md
@@ -1,0 +1,9 @@
+---
+title: CC Job Queue Length Total
+brief: Total number of background jobs in the queues that have yet to run for the first time. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Job Queue Length Total
+
+Total number of background jobs in the queues that have yet to run for the first time. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.log_count.all.md
+++ b/cloudfoundry/docs/cc.log_count.all.md
@@ -1,0 +1,9 @@
+---
+title: CC Log Count All
+brief: Total number of log messages, sum of messages of all severity levels. The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Log Count All
+
+Total number of log messages, sum of messages of all severity levels. The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.log_count.debug.md
+++ b/cloudfoundry/docs/cc.log_count.debug.md
@@ -1,0 +1,9 @@
+---
+title: CC Log Count Debug
+brief: Number of log messages of severity “debug.” The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Log Count Debug
+
+Number of log messages of severity “debug.” The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.log_count.debug1.md
+++ b/cloudfoundry/docs/cc.log_count.debug1.md
@@ -1,0 +1,9 @@
+---
+title: CC Log Count Debug1
+brief: Not used.
+metric_type: gauge
+---
+
+### CC Log Count Debug1
+
+Not used.

--- a/cloudfoundry/docs/cc.log_count.debug2.md
+++ b/cloudfoundry/docs/cc.log_count.debug2.md
@@ -1,0 +1,9 @@
+---
+title: CC Log Count Debug2
+brief: Number of log messages of severity “debug2.” The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Log Count Debug2
+
+Number of log messages of severity “debug2.” The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.log_count.info.md
+++ b/cloudfoundry/docs/cc.log_count.info.md
@@ -1,0 +1,9 @@
+---
+title: CC Log Count Info
+brief: Number of log messages of severity “info.” Examples of info messages are droplet created, copying package, uploading package, access denied due to insufficient scope, job logging, blobstore actions, staging requests, and app running requests. The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Log Count Info
+
+Number of log messages of severity “info.” Examples of info messages are droplet created, copying package, uploading package, access denied due to insufficient scope, job logging, blobstore actions, staging requests, and app running requests. The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.log_count.off.md
+++ b/cloudfoundry/docs/cc.log_count.off.md
@@ -1,0 +1,9 @@
+---
+title: CC Log Count Off
+brief: Number of log messages of severity “off.” The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Log Count Off
+
+Number of log messages of severity “off.” The count resets when the Cloud Controller process is restarted. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.tasks_running.memory_in_mb.md
+++ b/cloudfoundry/docs/cc.tasks_running.memory_in_mb.md
@@ -1,0 +1,9 @@
+---
+title: CC Tasks Running Memory in Mb
+brief: Memory being consumed by all currently running tasks. Emitted every 30 seconds per VM. This metric is only seen in version 3 of the Cloud Foundry API.
+metric_type: gauge
+---
+
+### CC Tasks Running Memory in Mb
+
+Memory being consumed by all currently running tasks. Emitted every 30 seconds per VM. This metric is only seen in version 3 of the Cloud Foundry API.

--- a/cloudfoundry/docs/cc.thread_info.event_machine.connection_count.md
+++ b/cloudfoundry/docs/cc.thread_info.event_machine.connection_count.md
@@ -1,0 +1,9 @@
+---
+title: CC Thread Info Event Machine Connection Count
+brief: Number of open connections to event machine. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Thread Info Event Machine Connection Count
+
+Number of open connections to event machine. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.thread_info.event_machine.resultqueue.num_waiting.md
+++ b/cloudfoundry/docs/cc.thread_info.event_machine.resultqueue.num_waiting.md
@@ -1,0 +1,9 @@
+---
+title: CC Thread Info Event Machine Resultqueue Num Waiting
+brief: Number of scheduled tasks in the result. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Thread Info Event Machine Resultqueue Num Waiting
+
+Number of scheduled tasks in the result. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.thread_info.event_machine.resultqueue.size.md
+++ b/cloudfoundry/docs/cc.thread_info.event_machine.resultqueue.size.md
@@ -1,0 +1,9 @@
+---
+title: CC Thread Info Event Machine Resultqueue Size
+brief: Number of unscheduled tasks in the result. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Thread Info Event Machine Resultqueue Size
+
+Number of unscheduled tasks in the result. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.thread_info.event_machine.threadqueue.num_waiting.md
+++ b/cloudfoundry/docs/cc.thread_info.event_machine.threadqueue.num_waiting.md
@@ -1,0 +1,9 @@
+---
+title: CC Thread Info Event Machine Threadqueue Num Waiting
+brief: Number of scheduled tasks in the threadqueue. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Thread Info Event Machine Threadqueue Num Waiting
+
+Number of scheduled tasks in the threadqueue. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.thread_info.event_machine.threadqueue.size.md
+++ b/cloudfoundry/docs/cc.thread_info.event_machine.threadqueue.size.md
@@ -1,0 +1,9 @@
+---
+title: CC Thread Info Event Machine Threadqueue Size
+brief: Number of unscheduled tasks in the threadqueue. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Thread Info Event Machine Threadqueue Size
+
+Number of unscheduled tasks in the threadqueue. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.thread_info.thread_count.md
+++ b/cloudfoundry/docs/cc.thread_info.thread_count.md
@@ -1,0 +1,9 @@
+---
+title: CC Thread Info Thread Count
+brief: Total number of threads that are either runnable or stopped. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Thread Info Thread Count
+
+Total number of threads that are either runnable or stopped. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.total_users.md
+++ b/cloudfoundry/docs/cc.total_users.md
@@ -1,0 +1,9 @@
+---
+title: CC Total Users
+brief: Total number of users ever created, including inactive users. Emitted every 10 minutes per VM.
+metric_type: gauge
+---
+
+### CC Total Users
+
+Total number of users ever created, including inactive users. Emitted every 10 minutes per VM.

--- a/cloudfoundry/docs/cc.vcap_sinatra.recent_errors.md
+++ b/cloudfoundry/docs/cc.vcap_sinatra.recent_errors.md
@@ -1,0 +1,9 @@
+---
+title: CC Vcap Sinatra Recent Errors
+brief: 50 most recent errors. DEPRECATED
+metric_type: gauge
+---
+
+### CC Vcap Sinatra Recent Errors
+
+50 most recent errors. DEPRECATED

--- a/cloudfoundry/docs/cc.vitals.cpu.md
+++ b/cloudfoundry/docs/cc.vitals.cpu.md
@@ -1,0 +1,9 @@
+---
+title: CC Vitals Cpu
+brief: Percentage of CPU used by the Cloud Controller process. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Vitals Cpu
+
+Percentage of CPU used by the Cloud Controller process. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.vitals.cpu_load_avg.md
+++ b/cloudfoundry/docs/cc.vitals.cpu_load_avg.md
@@ -1,0 +1,9 @@
+---
+title: CC Vitals Cpu Load Avg
+brief: System CPU load averaged over the last 1 minute according to the OS. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Vitals Cpu Load Avg
+
+System CPU load averaged over the last 1 minute according to the OS. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.vitals.mem_bytes.md
+++ b/cloudfoundry/docs/cc.vitals.mem_bytes.md
@@ -1,0 +1,9 @@
+---
+title: CC Vitals Mem Bytes
+brief: The RSS bytes (resident set size) or real memory of the Cloud Controller process. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Vitals Mem Bytes
+
+The RSS bytes (resident set size) or real memory of the Cloud Controller process. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.vitals.mem_free_bytes.md
+++ b/cloudfoundry/docs/cc.vitals.mem_free_bytes.md
@@ -1,0 +1,9 @@
+---
+title: CC Vitals Mem Free Bytes
+brief: Total memory available according to the OS. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Vitals Mem Free Bytes
+
+Total memory available according to the OS. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.vitals.mem_used_bytes.md
+++ b/cloudfoundry/docs/cc.vitals.mem_used_bytes.md
@@ -1,0 +1,9 @@
+---
+title: CC Vitals Mem Used Bytes
+brief: Total memory used (active + wired) according to the OS. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Vitals Mem Used Bytes
+
+Total memory used (active + wired) according to the OS. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.vitals.num_cores.md
+++ b/cloudfoundry/docs/cc.vitals.num_cores.md
@@ -1,0 +1,9 @@
+---
+title: CC Vitals Num Cores
+brief: The number of CPUs of a host machine. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Vitals Num Cores
+
+The number of CPUs of a host machine. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc.vitals.uptime.md
+++ b/cloudfoundry/docs/cc.vitals.uptime.md
@@ -1,0 +1,9 @@
+---
+title: CC Vitals Uptime
+brief: The uptime of the Cloud Controller process in seconds. Emitted every 30 seconds per VM.
+metric_type: gauge
+---
+
+### CC Vitals Uptime
+
+The uptime of the Cloud Controller process in seconds. Emitted every 30 seconds per VM.

--- a/cloudfoundry/docs/cc_uploader.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/cc_uploader.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: CC Uploader Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### CC Uploader Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/cc_uploader.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/cc_uploader.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: CC Uploader Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### CC Uploader Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/cc_uploader.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/cc_uploader.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: CC Uploader Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### CC Uploader Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/cc_uploader.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/cc_uploader.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: CC Uploader Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### CC Uploader Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/cc_uploader.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/cc_uploader.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: CC Uploader Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### CC Uploader Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/cc_uploader.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/cc_uploader.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: CC Uploader Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### CC Uploader Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/cc_uploader.numCPUS.md
+++ b/cloudfoundry/docs/cc_uploader.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: CC Uploader Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### CC Uploader Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/cc_uploader.numGoRoutines.md
+++ b/cloudfoundry/docs/cc_uploader.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: CC Uploader Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### CC Uploader Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/etcd.CompareAndDeleteFail.md
+++ b/cloudfoundry/docs/etcd.CompareAndDeleteFail.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Compare and Delete Fail
+brief: CompareAndDeleteFail operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Compare and Delete Fail
+
+CompareAndDeleteFail operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.CompareAndDeleteSuccess.md
+++ b/cloudfoundry/docs/etcd.CompareAndDeleteSuccess.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Compare and Delete Success
+brief: CompareAndDeleteSuccess operation countEmitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Compare and Delete Success
+
+CompareAndDeleteSuccess operation countEmitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.CompareAndSwapFail.md
+++ b/cloudfoundry/docs/etcd.CompareAndSwapFail.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Compare and Swap Fail
+brief: CompareAndSwapFail operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Compare and Swap Fail
+
+CompareAndSwapFail operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.CompareAndSwapSuccess.md
+++ b/cloudfoundry/docs/etcd.CompareAndSwapSuccess.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Compare and Swap Success
+brief: CompareAndSwapSuccess operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Compare and Swap Success
+
+CompareAndSwapSuccess operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.CreateFail.md
+++ b/cloudfoundry/docs/etcd.CreateFail.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Create Fail
+brief: CreateFail operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Create Fail
+
+CreateFail operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.CreateSuccess.md
+++ b/cloudfoundry/docs/etcd.CreateSuccess.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Create Success
+brief: CreateSuccess operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Create Success
+
+CreateSuccess operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.DeleteFail.md
+++ b/cloudfoundry/docs/etcd.DeleteFail.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Delete Fail
+brief: DeleteFail operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Delete Fail
+
+DeleteFail operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.DeleteSuccess.md
+++ b/cloudfoundry/docs/etcd.DeleteSuccess.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Delete Success
+brief: DeleteSuccess operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Delete Success
+
+DeleteSuccess operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.EtcdIndex.md
+++ b/cloudfoundry/docs/etcd.EtcdIndex.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Etcd Index
+brief: X-Etcd-Index value from the /stats/store endpoint. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Etcd Index
+
+X-Etcd-Index value from the /stats/store endpoint. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.ExpireCount.md
+++ b/cloudfoundry/docs/etcd.ExpireCount.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Expire Count
+brief: ExpireCount operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Expire Count
+
+ExpireCount operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.Followers.md
+++ b/cloudfoundry/docs/etcd.Followers.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Followers
+brief: Number of etcd followers. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Followers
+
+Number of etcd followers. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.GetsFail.md
+++ b/cloudfoundry/docs/etcd.GetsFail.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Gets Fail
+brief: GetsFail operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Gets Fail
+
+GetsFail operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.GetsSuccess.md
+++ b/cloudfoundry/docs/etcd.GetsSuccess.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Gets Success
+brief: GetsSuccess operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Gets Success
+
+GetsSuccess operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.IsLeader.md
+++ b/cloudfoundry/docs/etcd.IsLeader.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Is Leader
+brief: 1 if the current server is the leader, 0 if it is a follower. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Is Leader
+
+1 if the current server is the leader, 0 if it is a follower. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.Latency.md
+++ b/cloudfoundry/docs/etcd.Latency.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Latency
+brief: Current latency in milliseconds from leader to a specific follower. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Latency
+
+Current latency in milliseconds from leader to a specific follower. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.RaftIndex.md
+++ b/cloudfoundry/docs/etcd.RaftIndex.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Raft Index
+brief: X-Raft-Index value from the /stats/store endpoint. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Raft Index
+
+X-Raft-Index value from the /stats/store endpoint. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.RaftTerm.md
+++ b/cloudfoundry/docs/etcd.RaftTerm.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Raft Term
+brief: X-Raft-Term value from the /stats/store endpoint. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Raft Term
+
+X-Raft-Term value from the /stats/store endpoint. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.ReceivedAppendRequests.md
+++ b/cloudfoundry/docs/etcd.ReceivedAppendRequests.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Received Append Requests
+brief: Number of append requests this node has processed. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Received Append Requests
+
+Number of append requests this node has processed. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.ReceivingBandwidthRate.md
+++ b/cloudfoundry/docs/etcd.ReceivingBandwidthRate.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Receiving Bandwidth Rate
+brief: Number of bytes per second this node is receiving (follower only). Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Receiving Bandwidth Rate
+
+Number of bytes per second this node is receiving (follower only). Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.ReceivingRequestRate.md
+++ b/cloudfoundry/docs/etcd.ReceivingRequestRate.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Receiving Request Rate
+brief: Number of requests per second this node is receiving (follower only). Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Receiving Request Rate
+
+Number of requests per second this node is receiving (follower only). Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.SendingBandwidthRate.md
+++ b/cloudfoundry/docs/etcd.SendingBandwidthRate.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Sending Bandwidth Rate
+brief: Number of bytes per second this node is sending (leader only). This value is undefined on single member clusters. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Sending Bandwidth Rate
+
+Number of bytes per second this node is sending (leader only). This value is undefined on single member clusters. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.SendingRequestRate.md
+++ b/cloudfoundry/docs/etcd.SendingRequestRate.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Sending Request Rate
+brief: Number of requests per second this node is sending (leader only). This value is undefined on single member clusters. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Sending Request Rate
+
+Number of requests per second this node is sending (leader only). This value is undefined on single member clusters. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.SentAppendRequests.md
+++ b/cloudfoundry/docs/etcd.SentAppendRequests.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Sent Append Requests
+brief: Number of requests that this node has sent. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Sent Append Requests
+
+Number of requests that this node has sent. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.SetsFail.md
+++ b/cloudfoundry/docs/etcd.SetsFail.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Sets Fail
+brief: SetsFail operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Sets Fail
+
+SetsFail operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.SetsSuccess.md
+++ b/cloudfoundry/docs/etcd.SetsSuccess.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Sets Success
+brief: SetsSuccess operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Sets Success
+
+SetsSuccess operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.UpdateFail.md
+++ b/cloudfoundry/docs/etcd.UpdateFail.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Update Fail
+brief: UpdateFail operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Update Fail
+
+UpdateFail operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.UpdateSuccess.md
+++ b/cloudfoundry/docs/etcd.UpdateSuccess.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Update Success
+brief: UpdateSuccess operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Update Success
+
+UpdateSuccess operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/etcd.Watchers.md
+++ b/cloudfoundry/docs/etcd.Watchers.md
@@ -1,0 +1,9 @@
+---
+title: Etcd Watchers
+brief: Watchers operation count. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Etcd Watchers
+
+Watchers operation count. Emitted every 30 seconds.

--- a/cloudfoundry/docs/file_server.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/file_server.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: File Server Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### File Server Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/file_server.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/file_server.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: File Server Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### File Server Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/file_server.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/file_server.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: File Server Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### File Server Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/file_server.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/file_server.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: File Server Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### File Server Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/file_server.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/file_server.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: File Server Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### File Server Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/file_server.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/file_server.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: File Server Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### File Server Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/file_server.numCPUS.md
+++ b/cloudfoundry/docs/file_server.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: File Server Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### File Server Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/file_server.numGoRoutines.md
+++ b/cloudfoundry/docs/file_server.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: File Server Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### File Server Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/garden_linux.BackingStores.md
+++ b/cloudfoundry/docs/garden_linux.BackingStores.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Backing Stores
+brief: Number of container backing store files. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Garden Linux Backing Stores
+
+Number of container backing store files. Emitted every 30 seconds.

--- a/cloudfoundry/docs/garden_linux.DepotDirs.md
+++ b/cloudfoundry/docs/garden_linux.DepotDirs.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Depot Dirs
+brief: Number of directories in the Garden depot. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Garden Linux Depot Dirs
+
+Number of directories in the Garden depot. Emitted every 30 seconds.

--- a/cloudfoundry/docs/garden_linux.LoopDevices.md
+++ b/cloudfoundry/docs/garden_linux.LoopDevices.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Loop Devices
+brief: Number of attached loop devices. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Garden Linux Loop Devices
+
+Number of attached loop devices. Emitted every 30 seconds.

--- a/cloudfoundry/docs/garden_linux.MetricsReporting.md
+++ b/cloudfoundry/docs/garden_linux.MetricsReporting.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Metrics Reporting
+brief: How long it took to emit the BackingStores, DepotDirs, and LoopDevices metrics. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Garden Linux Metrics Reporting
+
+How long it took to emit the BackingStores, DepotDirs, and LoopDevices metrics. Emitted every 30 seconds.

--- a/cloudfoundry/docs/garden_linux.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/garden_linux.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### Garden Linux Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/garden_linux.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/garden_linux.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Garden Linux Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/garden_linux.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/garden_linux.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Garden Linux Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/garden_linux.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/garden_linux.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Garden Linux Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/garden_linux.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/garden_linux.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Garden Linux Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/garden_linux.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/garden_linux.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Garden Linux Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/garden_linux.numCPUS.md
+++ b/cloudfoundry/docs/garden_linux.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Garden Linux Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/garden_linux.numGoRoutines.md
+++ b/cloudfoundry/docs/garden_linux.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Garden Linux Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### Garden Linux Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/nsync_bulker.DesiredLRPSyncDuration.md
+++ b/cloudfoundry/docs/nsync_bulker.DesiredLRPSyncDuration.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Desired LRP Sync Duration
+brief: Time in nanoseconds that the nsync-bulker took to synchronize CF apps and Diego DesiredLRPs. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Nsync Bulker Desired LRP Sync Duration
+
+Time in nanoseconds that the nsync-bulker took to synchronize CF apps and Diego DesiredLRPs. Emitted every 30 seconds.

--- a/cloudfoundry/docs/nsync_bulker.LRPsDesired.md
+++ b/cloudfoundry/docs/nsync_bulker.LRPsDesired.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker LR Ps Desired
+brief: Cumulative number of LRPs desired through the nsync API. Emitted on each request desiring a new LRP, every 30 seconds.
+metric_type: gauge
+---
+
+### Nsync Bulker LR Ps Desired
+
+Cumulative number of LRPs desired through the nsync API. Emitted on each request desiring a new LRP, every 30 seconds.

--- a/cloudfoundry/docs/nsync_bulker.LockHeld.v1-locks-nsync_bulker_lock.md
+++ b/cloudfoundry/docs/nsync_bulker.LockHeld.v1-locks-nsync_bulker_lock.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Lock Held V1-Locks-Nsync Bulker Lock
+brief: Whether an nsync-bulker holds the nsync-bulker lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active nsync-bulker.
+metric_type: gauge
+---
+
+### Nsync Bulker Lock Held V1-Locks-Nsync Bulker Lock
+
+Whether an nsync-bulker holds the nsync-bulker lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active nsync-bulker.

--- a/cloudfoundry/docs/nsync_bulker.LockHeldDuration.v1-locks-nsync_bulker_lock.md
+++ b/cloudfoundry/docs/nsync_bulker.LockHeldDuration.v1-locks-nsync_bulker_lock.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Lock Held Duration V1-Locks-Nsync Bulker Lock
+brief: Time in nanoseconds that the active nsync-bulker has held the convergence lock. Emitted every 30 seconds by the active nsync-bulker.
+metric_type: gauge
+---
+
+### Nsync Bulker Lock Held Duration V1-Locks-Nsync Bulker Lock
+
+Time in nanoseconds that the active nsync-bulker has held the convergence lock. Emitted every 30 seconds by the active nsync-bulker.

--- a/cloudfoundry/docs/nsync_bulker.NsyncInvalidDesiredLRPsFound.md
+++ b/cloudfoundry/docs/nsync_bulker.NsyncInvalidDesiredLRPsFound.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Nsync Invalid Desired LR Ps Found
+brief: Number of invalid DesiredLRPs found during nsync-bulker periodic synchronization. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Nsync Bulker Nsync Invalid Desired LR Ps Found
+
+Number of invalid DesiredLRPs found during nsync-bulker periodic synchronization. Emitted every 30 seconds.

--- a/cloudfoundry/docs/nsync_bulker.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/nsync_bulker.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### Nsync Bulker Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/nsync_bulker.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/nsync_bulker.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Nsync Bulker Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/nsync_bulker.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/nsync_bulker.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Nsync Bulker Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/nsync_bulker.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/nsync_bulker.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Nsync Bulker Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/nsync_bulker.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/nsync_bulker.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Nsync Bulker Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/nsync_bulker.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/nsync_bulker.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Nsync Bulker Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/nsync_bulker.numCPUS.md
+++ b/cloudfoundry/docs/nsync_bulker.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Nsync Bulker Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/nsync_bulker.numGoRoutines.md
+++ b/cloudfoundry/docs/nsync_bulker.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Bulker Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### Nsync Bulker Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/nsync_listener.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/nsync_listener.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Listener Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### Nsync Listener Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/nsync_listener.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/nsync_listener.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Listener Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Nsync Listener Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/nsync_listener.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/nsync_listener.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Listener Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Nsync Listener Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/nsync_listener.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/nsync_listener.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Listener Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Nsync Listener Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/nsync_listener.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/nsync_listener.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Listener Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Nsync Listener Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/nsync_listener.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/nsync_listener.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Listener Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Nsync Listener Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/nsync_listener.numCPUS.md
+++ b/cloudfoundry/docs/nsync_listener.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Listener Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Nsync Listener Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/nsync_listener.numGoRoutines.md
+++ b/cloudfoundry/docs/nsync_listener.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Nsync Listener Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### Nsync Listener Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/rep.CM.md
+++ b/cloudfoundry/docs/rep.CM.md
@@ -1,0 +1,9 @@
+---
+title: Rep CM
+brief: Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Rep CM
+
+Emitted every 30 seconds.

--- a/cloudfoundry/docs/rep.CapacityRemainingContainers.md
+++ b/cloudfoundry/docs/rep.CapacityRemainingContainers.md
@@ -1,0 +1,9 @@
+---
+title: Rep Capacity Remaining Containers
+brief: Remaining number of containers this cell can host. Emitted every 60 seconds.
+metric_type: gauge
+---
+
+### Rep Capacity Remaining Containers
+
+Remaining number of containers this cell can host. Emitted every 60 seconds.

--- a/cloudfoundry/docs/rep.CapacityTotalContainers.md
+++ b/cloudfoundry/docs/rep.CapacityTotalContainers.md
@@ -1,0 +1,9 @@
+---
+title: Rep Capacity Total Containers
+brief: Total number of containers this cell can host. Emitted every 60 seconds.
+metric_type: gauge
+---
+
+### Rep Capacity Total Containers
+
+Total number of containers this cell can host. Emitted every 60 seconds.

--- a/cloudfoundry/docs/rep.GardenContainerCreationDuration.md
+++ b/cloudfoundry/docs/rep.GardenContainerCreationDuration.md
@@ -1,0 +1,9 @@
+---
+title: Rep Garden Container Creation Duration
+brief: Time in nanoseconds that the rep Garden backend took to create a container. Emitted after every successful container creation.
+metric_type: gauge
+---
+
+### Rep Garden Container Creation Duration
+
+Time in nanoseconds that the rep Garden backend took to create a container. Emitted after every successful container creation.

--- a/cloudfoundry/docs/rep.LogMessage.md
+++ b/cloudfoundry/docs/rep.LogMessage.md
@@ -1,0 +1,9 @@
+---
+title: Rep Log Message
+brief: Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Rep Log Message
+
+Emitted every 30 seconds.

--- a/cloudfoundry/docs/rep.RepBulkSyncDuration.md
+++ b/cloudfoundry/docs/rep.RepBulkSyncDuration.md
@@ -1,0 +1,9 @@
+---
+title: Rep Rep Bulk Sync Duration
+brief: Time in nanoseconds that the cell rep took to synchronize the ActualLRPs it has claimed with its actual garden containers. Emitted every 30 seconds by each rep.
+metric_type: gauge
+---
+
+### Rep Rep Bulk Sync Duration
+
+Time in nanoseconds that the cell rep took to synchronize the ActualLRPs it has claimed with its actual garden containers. Emitted every 30 seconds by each rep.

--- a/cloudfoundry/docs/rep.logSenderTotalMessagesRead.md
+++ b/cloudfoundry/docs/rep.logSenderTotalMessagesRead.md
@@ -1,0 +1,9 @@
+---
+title: Rep Log Sender Total Messages Read
+brief: Count of application log messages sent by Diego Executor. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Rep Log Sender Total Messages Read
+
+Count of application log messages sent by Diego Executor. Emitted every 30 seconds.

--- a/cloudfoundry/docs/rep.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/rep.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Rep Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### Rep Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/rep.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/rep.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Rep Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Rep Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/rep.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/rep.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Rep Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Rep Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/rep.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/rep.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Rep Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Rep Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/rep.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/rep.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Rep Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Rep Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/rep.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/rep.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Rep Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Rep Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/rep.numCPUS.md
+++ b/cloudfoundry/docs/rep.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Rep Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Rep Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/rep.numGoRoutines.md
+++ b/cloudfoundry/docs/rep.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Rep Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### Rep Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/route_emitter.LockHeld.v1-locks-route_emitter_lock.md
+++ b/cloudfoundry/docs/route_emitter.LockHeld.v1-locks-route_emitter_lock.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Lock Held V1-Locks-Route Emitter Lock
+brief: Whether a route-emitter holds the route-emitter lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active route-emitter.
+metric_type: gauge
+---
+
+### Route Emitter Lock Held V1-Locks-Route Emitter Lock
+
+Whether a route-emitter holds the route-emitter lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active route-emitter.

--- a/cloudfoundry/docs/route_emitter.LockHeldDuration.v1-locks-route_emitter_lock.md
+++ b/cloudfoundry/docs/route_emitter.LockHeldDuration.v1-locks-route_emitter_lock.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Lock Held Duration V1-Locks-Route Emitter Lock
+brief: Time in nanoseconds that the active route-emitter has held the route-emitter lock. Emitted every 30 seconds by the active route-emitter.
+metric_type: gauge
+---
+
+### Route Emitter Lock Held Duration V1-Locks-Route Emitter Lock
+
+Time in nanoseconds that the active route-emitter has held the route-emitter lock. Emitted every 30 seconds by the active route-emitter.

--- a/cloudfoundry/docs/route_emitter.MessagesEmitted.md
+++ b/cloudfoundry/docs/route_emitter.MessagesEmitted.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Messages Emitted
+brief: The cumulative number of registration messages that this process has sent. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Route Emitter Messages Emitted
+
+The cumulative number of registration messages that this process has sent. Emitted every 30 seconds.

--- a/cloudfoundry/docs/route_emitter.RouteEmitterSyncDuration.md
+++ b/cloudfoundry/docs/route_emitter.RouteEmitterSyncDuration.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Route Emitter Sync Duration
+brief: Time in nanoseconds that the active route-emitter took to perform its synchronization pass. Emitted every 60 seconds.
+metric_type: gauge
+---
+
+### Route Emitter Route Emitter Sync Duration
+
+Time in nanoseconds that the active route-emitter took to perform its synchronization pass. Emitted every 60 seconds.

--- a/cloudfoundry/docs/route_emitter.RoutesRegistered.md
+++ b/cloudfoundry/docs/route_emitter.RoutesRegistered.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Routes Registered
+brief: Cumulative number of route registrations emitted from the route-emitter as it reacts to changes to LRPs. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Route Emitter Routes Registered
+
+Cumulative number of route registrations emitted from the route-emitter as it reacts to changes to LRPs. Emitted every 30 seconds.

--- a/cloudfoundry/docs/route_emitter.RoutesSynced.md
+++ b/cloudfoundry/docs/route_emitter.RoutesSynced.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Routes Synced
+brief: Cumulative number of route registrations emitted from the route-emitter during its periodic route-table synchronization. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Route Emitter Routes Synced
+
+Cumulative number of route registrations emitted from the route-emitter during its periodic route-table synchronization. Emitted every 30 seconds.

--- a/cloudfoundry/docs/route_emitter.RoutesTotal.md
+++ b/cloudfoundry/docs/route_emitter.RoutesTotal.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Routes Total
+brief: Number of routes in the route-emitter’s routing table. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Route Emitter Routes Total
+
+Number of routes in the route-emitter’s routing table. Emitted every 30 seconds.

--- a/cloudfoundry/docs/route_emitter.RoutesUnregistered.md
+++ b/cloudfoundry/docs/route_emitter.RoutesUnregistered.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Routes Unregistered
+brief: Cumulative number of route unregistrations emitted from the route-emitter as it reacts to changes to LRPs. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Route Emitter Routes Unregistered
+
+Cumulative number of route unregistrations emitted from the route-emitter as it reacts to changes to LRPs. Emitted every 30 seconds.

--- a/cloudfoundry/docs/route_emitter.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/route_emitter.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### Route Emitter Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/route_emitter.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/route_emitter.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Route Emitter Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/route_emitter.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/route_emitter.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Route Emitter Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/route_emitter.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/route_emitter.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Route Emitter Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/route_emitter.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/route_emitter.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Route Emitter Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/route_emitter.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/route_emitter.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Route Emitter Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/route_emitter.numCPUS.md
+++ b/cloudfoundry/docs/route_emitter.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Route Emitter Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/route_emitter.numGoRoutines.md
+++ b/cloudfoundry/docs/route_emitter.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Route Emitter Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### Route Emitter Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/ssh_proxy.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/ssh_proxy.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: SSH Proxy Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### SSH Proxy Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/ssh_proxy.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/ssh_proxy.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: SSH Proxy Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### SSH Proxy Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/ssh_proxy.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/ssh_proxy.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: SSH Proxy Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### SSH Proxy Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/ssh_proxy.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/ssh_proxy.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: SSH Proxy Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### SSH Proxy Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/ssh_proxy.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/ssh_proxy.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: SSH Proxy Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### SSH Proxy Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/ssh_proxy.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/ssh_proxy.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: SSH Proxy Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### SSH Proxy Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/ssh_proxy.numCPUS.md
+++ b/cloudfoundry/docs/ssh_proxy.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: SSH Proxy Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### SSH Proxy Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/ssh_proxy.numGoRoutines.md
+++ b/cloudfoundry/docs/ssh_proxy.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: SSH Proxy Num Go Routines
+brief: Instantaneous number of active goroutines in the process .
+metric_type: gauge
+---
+
+### SSH Proxy Num Go Routines
+
+Instantaneous number of active goroutines in the process .

--- a/cloudfoundry/docs/stager.StagingRequestFailedDuration.md
+++ b/cloudfoundry/docs/stager.StagingRequestFailedDuration.md
@@ -1,0 +1,9 @@
+---
+title: Stager Staging Request Failed Duration
+brief: Time in nanoseconds that the failed staging task took to run. Emitted each time a staging task fails.
+metric_type: gauge
+---
+
+### Stager Staging Request Failed Duration
+
+Time in nanoseconds that the failed staging task took to run. Emitted each time a staging task fails.

--- a/cloudfoundry/docs/stager.StagingRequestSucceededDuration.md
+++ b/cloudfoundry/docs/stager.StagingRequestSucceededDuration.md
@@ -1,0 +1,9 @@
+---
+title: Stager Staging Request Succeeded Duration
+brief: Time in nanoseconds that the successful staging task took to run. Emitted each time a staging task completes successfully.
+metric_type: gauge
+---
+
+### Stager Staging Request Succeeded Duration
+
+Time in nanoseconds that the successful staging task took to run. Emitted each time a staging task completes successfully.

--- a/cloudfoundry/docs/stager.StagingRequestsFailed.md
+++ b/cloudfoundry/docs/stager.StagingRequestsFailed.md
@@ -1,0 +1,9 @@
+---
+title: Stager Staging Requests Failed
+brief: Cumulative number of failed staging tasks handled by each stager. Emitted every time a staging task fails.
+metric_type: gauge
+---
+
+### Stager Staging Requests Failed
+
+Cumulative number of failed staging tasks handled by each stager. Emitted every time a staging task fails.

--- a/cloudfoundry/docs/stager.StagingRequestsSucceeded.md
+++ b/cloudfoundry/docs/stager.StagingRequestsSucceeded.md
@@ -1,0 +1,9 @@
+---
+title: Stager Staging Requests Succeeded
+brief: Cumulative number of successful staging tasks handled by each stager. Emitted every time a staging task completes successfully.
+metric_type: gauge
+---
+
+### Stager Staging Requests Succeeded
+
+Cumulative number of successful staging tasks handled by each stager. Emitted every time a staging task completes successfully.

--- a/cloudfoundry/docs/stager.StagingStartRequestsReceived.md
+++ b/cloudfoundry/docs/stager.StagingStartRequestsReceived.md
@@ -1,0 +1,9 @@
+---
+title: Stager Staging Start Requests Received
+brief: Cumulative number of requests to start a staging task. Emitted by a stager each time it handles a request.
+metric_type: gauge
+---
+
+### Stager Staging Start Requests Received
+
+Cumulative number of requests to start a staging task. Emitted by a stager each time it handles a request.

--- a/cloudfoundry/docs/stager.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/stager.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Stager Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### Stager Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/stager.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/stager.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Stager Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Stager Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/stager.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/stager.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Stager Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Stager Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/stager.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/stager.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Stager Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Stager Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/stager.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/stager.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Stager Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Stager Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/stager.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/stager.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Stager Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Stager Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/stager.numCPUS.md
+++ b/cloudfoundry/docs/stager.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Stager Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Stager Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/stager.numGoRoutines.md
+++ b/cloudfoundry/docs/stager.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Stager Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### Stager Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/syslog_drain_binder.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/syslog_drain_binder.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Memory Stats Last GC Pause Time NS
+brief: Duration of the last Garbage Collector pause in nanoseconds.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Memory Stats Last GC Pause Time NS
+
+Duration of the last Garbage Collector pause in nanoseconds.

--- a/cloudfoundry/docs/syslog_drain_binder.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/syslog_drain_binder.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/syslog_drain_binder.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/syslog_drain_binder.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/syslog_drain_binder.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/syslog_drain_binder.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/syslog_drain_binder.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/syslog_drain_binder.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/syslog_drain_binder.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/syslog_drain_binder.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/syslog_drain_binder.numCPUS.md
+++ b/cloudfoundry/docs/syslog_drain_binder.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/syslog_drain_binder.numGoRoutines.md
+++ b/cloudfoundry/docs/syslog_drain_binder.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Num Go Routines
+brief: Instantaneous number of active goroutines in the Doppler process.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Num Go Routines
+
+Instantaneous number of active goroutines in the Doppler process.

--- a/cloudfoundry/docs/syslog_drain_binder.pollCount.md
+++ b/cloudfoundry/docs/syslog_drain_binder.pollCount.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Poll Count
+brief: Number of times the syslog drain binder has polled the cloud controller for syslog drain bindings. Emitted every 30 seconds.
+metric_type: cumulative_counter
+---
+
+### Syslog Drain Binder Poll Count
+
+Number of times the syslog drain binder has polled the cloud controller for syslog drain bindings. Emitted every 30 seconds.

--- a/cloudfoundry/docs/syslog_drain_binder.totalDrains.md
+++ b/cloudfoundry/docs/syslog_drain_binder.totalDrains.md
@@ -1,0 +1,9 @@
+---
+title: Syslog Drain Binder Total Drains
+brief: Number of syslog drains returned by cloud controller. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### Syslog Drain Binder Total Drains
+
+Number of syslog drains returned by cloud controller. Emitted every 30 seconds.

--- a/cloudfoundry/docs/tps_listener.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/tps_listener.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: TPS Listener Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### TPS Listener Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/tps_listener.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/tps_listener.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: TPS Listener Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### TPS Listener Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/tps_listener.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/tps_listener.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: TPS Listener Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### TPS Listener Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/tps_listener.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/tps_listener.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: TPS Listener Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### TPS Listener Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/tps_listener.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/tps_listener.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: TPS Listener Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### TPS Listener Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/tps_listener.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/tps_listener.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: TPS Listener Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### TPS Listener Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/tps_listener.numCPUS.md
+++ b/cloudfoundry/docs/tps_listener.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: TPS Listener Num CPUS
+brief: Number of CPUs on the machine.
+metric_type: gauge
+---
+
+### TPS Listener Num CPUS
+
+Number of CPUs on the machine.

--- a/cloudfoundry/docs/tps_listener.numGoRoutines.md
+++ b/cloudfoundry/docs/tps_listener.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: TPS Listener Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### TPS Listener Num Go Routines
+
+Instantaneous number of active goroutines in the process.

--- a/cloudfoundry/docs/tps_watcher.LockHeld.v1-locks-tps_watcher_lock.md
+++ b/cloudfoundry/docs/tps_watcher.LockHeld.v1-locks-tps_watcher_lock.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Lock Held V1-Locks-Tps Watcher Lock
+brief: Whether a tps-watcher holds the tps-watcher lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active tps-watcher.
+metric_type: gauge
+---
+
+### TPS Watcher Lock Held V1-Locks-Tps Watcher Lock
+
+Whether a tps-watcher holds the tps-watcher lock: 1 means the lock is held, and 0 means the lock was lost. Emitted every 30 seconds by the active tps-watcher.

--- a/cloudfoundry/docs/tps_watcher.LockHeldDuration.v1-locks-tps_watcher_lock.md
+++ b/cloudfoundry/docs/tps_watcher.LockHeldDuration.v1-locks-tps_watcher_lock.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Lock Held Duration V1-Locks-Tps Watcher Lock
+brief: Time in nanoseconds that the active tps-watcher has held the convergence lock. Emitted every 30 seconds by the active tps-watcher.
+metric_type: gauge
+---
+
+### TPS Watcher Lock Held Duration V1-Locks-Tps Watcher Lock
+
+Time in nanoseconds that the active tps-watcher has held the convergence lock. Emitted every 30 seconds by the active tps-watcher.

--- a/cloudfoundry/docs/tps_watcher.memoryStats.lastGCPauseTimeNS.md
+++ b/cloudfoundry/docs/tps_watcher.memoryStats.lastGCPauseTimeNS.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Memory Stats Last GC Pause Time NS
+brief: Duration in nanoseconds of the last garbage collector pause.
+metric_type: gauge
+---
+
+### TPS Watcher Memory Stats Last GC Pause Time NS
+
+Duration in nanoseconds of the last garbage collector pause.

--- a/cloudfoundry/docs/tps_watcher.memoryStats.numBytesAllocated.md
+++ b/cloudfoundry/docs/tps_watcher.memoryStats.numBytesAllocated.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Memory Stats Num Bytes Allocated
+brief: Instantaneous count of bytes allocated and still in use.
+metric_type: gauge
+---
+
+### TPS Watcher Memory Stats Num Bytes Allocated
+
+Instantaneous count of bytes allocated and still in use.

--- a/cloudfoundry/docs/tps_watcher.memoryStats.numBytesAllocatedHeap.md
+++ b/cloudfoundry/docs/tps_watcher.memoryStats.numBytesAllocatedHeap.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Memory Stats Num Bytes Allocated Heap
+brief: Instantaneous count of bytes allocated on the main heap and still in use.
+metric_type: gauge
+---
+
+### TPS Watcher Memory Stats Num Bytes Allocated Heap
+
+Instantaneous count of bytes allocated on the main heap and still in use.

--- a/cloudfoundry/docs/tps_watcher.memoryStats.numBytesAllocatedStack.md
+++ b/cloudfoundry/docs/tps_watcher.memoryStats.numBytesAllocatedStack.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Memory Stats Num Bytes Allocated Stack
+brief: Instantaneous count of bytes used by the stack allocator.
+metric_type: gauge
+---
+
+### TPS Watcher Memory Stats Num Bytes Allocated Stack
+
+Instantaneous count of bytes used by the stack allocator.

--- a/cloudfoundry/docs/tps_watcher.memoryStats.numFrees.md
+++ b/cloudfoundry/docs/tps_watcher.memoryStats.numFrees.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Memory Stats Num Frees
+brief: Lifetime number of memory deallocations.
+metric_type: gauge
+---
+
+### TPS Watcher Memory Stats Num Frees
+
+Lifetime number of memory deallocations.

--- a/cloudfoundry/docs/tps_watcher.memoryStats.numMallocs.md
+++ b/cloudfoundry/docs/tps_watcher.memoryStats.numMallocs.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Memory Stats Num Mallocs
+brief: Lifetime number of memory allocations.
+metric_type: gauge
+---
+
+### TPS Watcher Memory Stats Num Mallocs
+
+Lifetime number of memory allocations.

--- a/cloudfoundry/docs/tps_watcher.numCPUS.md
+++ b/cloudfoundry/docs/tps_watcher.numCPUS.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Num CPUS
+brief: Number of CPUs on the machine. Emitted every 30 seconds.
+metric_type: gauge
+---
+
+### TPS Watcher Num CPUS
+
+Number of CPUs on the machine. Emitted every 30 seconds.

--- a/cloudfoundry/docs/tps_watcher.numGoRoutines.md
+++ b/cloudfoundry/docs/tps_watcher.numGoRoutines.md
@@ -1,0 +1,9 @@
+---
+title: TPS Watcher Num Go Routines
+brief: Instantaneous number of active goroutines in the process.
+metric_type: gauge
+---
+
+### TPS Watcher Num Go Routines
+
+Instantaneous number of active goroutines in the process.


### PR DESCRIPTION
The new metric files were created from a combination of https://docs.cloudfoundry.org/running/all_metrics.html and a custom logging function in the bridge to get metric types.  Each one should probably be manually reviewed at some point.

Existing metric docs added by Jay in phase 1 were left untouched but should still apply.