### PR TITLE
INT-106: NGINX Plus README Fix

### DIFF
--- a/collectd-nginx-plus/README.md
+++ b/collectd-nginx-plus/README.md
@@ -14,7 +14,7 @@ _This directory consolidates all the metadata associated with the NGINX Plus plu
 This is the SignalFx NGINX Plus plugin. Follow these instructions to install the NGINX Plus plugin for collectd.
 
 The [`niginx-plus-collectd`](https://github.com/signalfx/collectd-nginx-plus) plugin collects metrics about a single NGINX Plus instance,
-using the `/status` endpoints exposed with the [http_status_module](http://nginx.org/en/docs/http/ngx_http_status_module.html).
+using the `/status` endpoints exposed with the ngx_http_status_module, documentation [here](http://nginx.org/en/docs/http/ngx_http_status_module.html).
 
 #### FEATURES
 


### PR DESCRIPTION
Fixed the `ngx_http_status_module` doc link getting mangled.