### PR TITLE
link and text changes from host nav to infra nav

### DIFF
--- a/cloudfoundry/README.md
+++ b/cloudfoundry/README.md
@@ -17,7 +17,7 @@ Use this integration to monitor a Pivotal Cloud Foundry deployment. This integra
 
 ##### Infrastructure Page
 
-- **Infrastructure Navigator**: On the Infrastructure page in SignalFx, the Infrastructure Navigator visualizes Cloud Foundry instances as squares, colored by metrics including CPU, disk, and network. Additional views are provided for focus on the health and performance of specific Cloud Foundry services. [Click here to read more about the Infrastructure Page](http://docs.signalfx.com/en/latest/built-in-content/host-nav.html). 
+- **Infrastructure Navigator**: On the Infrastructure page in SignalFx, the Infrastructure Navigator visualizes Cloud Foundry instances as squares, colored by metrics including CPU, disk, and network. Additional views are provided for focus on the health and performance of specific Cloud Foundry services. [Click here to read more about the Infrastructure Page](https://docs.signalfx.com/en/latest/built-in-content/infra-nav.html). 
 
   [<img src='./img/infra_pcf_instances.png' width=200px>](./img/infra_pcf_instances.png)
 
@@ -26,11 +26,11 @@ Use this integration to monitor a Pivotal Cloud Foundry deployment. This integra
 This integration includes built-in dashboards listed under **Pivotal Cloud Foundry** on the Dashboards page in SignalFx. A sample include:
 
 - **Cloud Foundry Overview**: Overview of all activity in your Cloud Foundry environment.
-  
+
   [<img src='./img/dashboard_cloud_foundry_overview.png' width=200px>](./img/dashboard_cloud_foundry_overview.png)
 
 - **Cloud Foundry Architecture**: Focus on a single Cloud Foundry instance.
-  
+
   [<img src='./img/dashboard_cloud_foundry_instance.png' width=200px>](./img/dashboard_cloud_foundry_instance.png)
 
 ### REQUIREMENTS AND DEPENDENCIES

--- a/collectd/README.md
+++ b/collectd/README.md
@@ -25,7 +25,7 @@ All changes have been submitted back to the [collectd project](http://collectd.o
 
 Sending data using collectd allows you to take advantage of SignalFx’s extensive collectd support.
 
-- The [SignalFx Hosts page](http://docs.signalfx.com/en/latest/built-in-content/host-nav.html) visualizes hosts that are monitored using the SignalFx collectd agent.
+- The [SignalFx Infrastructure page](https://docs.signalfx.com/en/latest/built-in-content/infra-nav.html) visualizes hosts that are monitored using the SignalFx collectd agent.
 
   [<img src='./img/collectdhostspage.png' width=200px>](./img/collectdhostspage.png)
 
@@ -48,7 +48,7 @@ The SignalFx collectd agent is supported on the following operating systems:
 | RHEL/Centos | 6.x & 7.x |
 | Ubuntu  | 12.04, 14.04, 15.04 & 16.04 |
 
-You must have administrator (sudo) privileges to install this agent. 
+You must have administrator (sudo) privileges to install this agent.
 
 ### INSTALLATION
 
@@ -108,9 +108,9 @@ Installing the SignalFx collectd agent allows you to install many of the integra
 
 You can add a dimension to every datapoint that collectd sends to SignalFx by adding HTTP query parameters to the SignalFx ingest URL, part of the configuration for the `write_http` plugin. This allows you to add information about the host or environment to every metric. For instance, you could identify all metrics coming from production boxes with a dimension like `environment=prod`.
 
-The SignalFx URL to which collectd will transmit data is specified in `10-write_http-plugin.conf` and by default has a value like https://ingest.signalfx.com/v1/collectd. 
+The SignalFx URL to which collectd will transmit data is specified in `10-write_http-plugin.conf` and by default has a value like https://ingest.signalfx.com/v1/collectd.
 
-Append dimensions to the  URL as `sfxdim_[DIMENSION NAME]=[DIMENSION VALUE]`. Multiple dimensions may be specified. 
+Append dimensions to the  URL as `sfxdim_[DIMENSION NAME]=[DIMENSION VALUE]`. Multiple dimensions may be specified.
 
 For example, the following URL sends data points to SignalFx with the added dimensions `serverType=API` and `tier=middleware`.
 

--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -11,13 +11,13 @@ _This is a directory that consolidates all the metadata associated with the Sign
 
 ### DESCRIPTION
 
-[Telegraf](https://github.com/influxdata/telegraf) is an open source daemon that collects statistics from a system and publishes them to a destination of your choice. You can use Telegraf to monitor infrastructure metrics, and enable Telegraf plugins that monitor a wide range of software. 
+[Telegraf](https://github.com/influxdata/telegraf) is an open source daemon that collects statistics from a system and publishes them to a destination of your choice. You can use Telegraf to monitor infrastructure metrics, and enable Telegraf plugins that monitor a wide range of software.
 
 #### FEATURES
 
 Sending data using Telegraf allows you to take advantage of the following features:
 
-- The [SignalFx Infrastructure page](http://docs.signalfx.com/en/latest/built-in-content/host-nav.html) visualizes hosts that are monitored using the SignalFx Telegraf Agent.
+- The [SignalFx Infrastructure page](https://docs.signalfx.com/en/latest/built-in-content/infra-nav.html) visualizes hosts that are monitored using the SignalFx Telegraf Agent.
 
   [<img src='./img/telegrafhostspage.png' width=200px>](./img/telegrafhostspage.png)
 
@@ -52,7 +52,7 @@ unzip Linux-x86_64.zip
 ```bash
 ./telegraf config > telegraf.conf
 ```
-1. Modify the resulting configuration file to provide values that make sense for your environment, as described [below](#configuration). 
+1. Modify the resulting configuration file to provide values that make sense for your environment, as described [below](#configuration).
 1. Start the SignalFx Telegraf Agent, specifying the configuration file you generated in step 4.
 ```
 ./telegraf --config <path to the telegraf config file>
@@ -61,7 +61,7 @@ Note: This command only starts an executable. To ensure that the SignalFx Telegr
 
 ### CONFIGURATION
 
-Edit the configuration file `telegraf.conf` as shown below to configure the agent for use with SignalFx. 
+Edit the configuration file `telegraf.conf` as shown below to configure the agent for use with SignalFx.
 
 #### Enable required plugins
 
@@ -73,7 +73,7 @@ By default, the following plugin sections are listed in the configuration file b
 
 If you are not using InfluxDB, comment out the InfluxDB plugin configuration section `[[outputs.influxdb]]`.
 
-#### Set configuration values 
+#### Set configuration values
 
 In `telegraf.conf`, provide values for the configuration options listed below that make sense for your environment.
 


### PR DESCRIPTION
link text changes from host-nav to infra-nav for cloud foundry, collectd and telegraph. Text change from "Hosts page" to "Infrastructure page" for collectd.