### PR TITLE
Fix incorrect metric doc for memory.utilization

### DIFF
--- a/signalfx-metadata/docs/memory.utilization.md
+++ b/signalfx-metadata/docs/memory.utilization.md
@@ -7,14 +7,14 @@ metric_type: gauge
 
 This metric shows the amount of memory in use on this machine, as a percent of total memory available. 
 
-The SignalFx metadata plugin computes this metric based on the metrics output by the `memory` plugin for collectd and the `mem` plugin for Telegraf. First, compute the ratio of `memory.free` or `mem.free` to the sum of all memory metrics. Next, subtract that number from 1 to yield the ratio of memory that is not free, and multiply by 100 to display as percent, as follows: 
+The SignalFx metadata plugin computes this metric based on the metrics output by the `memory` plugin for collectd and the `mem` plugin for Telegraf. The calculation used is as follows:
 
 collectd
 ```
-100 * [1 - memory.free / sum(memory.*)]
+1.0 * memory.used / sum (memory.*) * 100
 ```
 
 Telegraf
 ```
-100 * [1 - mem.free / sum(mem.*)]
+1.0 * mem.used / sum (mem.*) * 100
 ```


### PR DESCRIPTION
Fixed the metric documentation for memory.utilization to reflect the actual calculation that the metadata plugin is using