### PR TITLE
Fix aws autoscaling data signature

### DIFF
--- a/aws-autoscaling/meta.yaml
+++ b/aws-autoscaling/meta.yaml
@@ -5,6 +5,6 @@
   "featured": false,
   "logo_large": "integration_awsautoscaling.png",
   "logo_small": "integration_awsautoscaling.png",
-  "data_signature": "namespace:\"AWS/Autoscaling\"",
+  "data_signature": "namespace:\"AWS/AutoScaling\"",
   "in_app_categories": ["AWSservicesMonitored"]
 }


### PR DESCRIPTION
The aws autoscaling data signature was incorrectly `AWS/Autoscaling` when it should be `AWS/AutoScaling`