### PR TITLE
deprecate collectd on Ubuntu Vivid 15.04

### DIFF
--- a/collectd-genericjmx/README.md
+++ b/collectd-genericjmx/README.md
@@ -35,7 +35,7 @@ From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:GenericJMX):
 
             yum install collectd-java
 
-    * Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
+    * Ubuntu 12.04, 14.04, 16.04 & Debian 7, 8:
         - This plugin is included with [SignalFx's collectd package](https://support.signalfx.com/hc/en-us/articles/208080123).
 
 2. Download SignalFx's sample JMX configuration file [20-javageneric.conf](https://github.com/signalfx/integrations/blob/master/collectd-genericjmx/20-javageneric.conf)

--- a/collectd-hbase/README.md
+++ b/collectd-hbase/README.md
@@ -25,7 +25,7 @@ Metadata associated with the HBase collectd plugin can be found [here](https://g
             yum install collectd-java
 
 
-    * Ubuntu 12.04, 14.04, 15.04 & Debian 7, 8:
+    * Ubuntu 12.04, 14.04, 16.04 & Debian 7, 8:
       - This plugin is included with [SignalFx's collectd package](https://github.com/signalfx/integrations/tree/master/collectd).
 
 2. Download SignalFx's sample JMX configuration file and sample Cassandra configuration file from the following URLs:

--- a/collectd/README.md
+++ b/collectd/README.md
@@ -46,7 +46,7 @@ The SignalFx collectd agent is supported on the following operating systems:
 | Debian  | 7, 8, & 9 |
 | Mac OS X | 10.8+ |
 | RHEL/Centos | 6.x & 7.x |
-| Ubuntu  | 12.04, 14.04, 15.04 & 16.04 |
+| Ubuntu  | 12.04, 14.04 & 16.04 |
 
 You must have administrator (sudo) privileges to install this agent.
 


### PR DESCRIPTION
Ubuntu 15.04 Vivid was End Of Lifed in early 2016.  We are no longer able to build packages for this platform because dependencies from Canonical and it's mirrors have been removed.

[Ubuntu 15.04 End Of Life Notice](https://lists.ubuntu.com/archives/ubuntu-announce/2016-January/000203.html)