### PR TITLE
Adding metric doc and 2.2.2 release of K8s agent

### DIFF
--- a/kubernetes/docs/kubernetes_node_ready.md
+++ b/kubernetes/docs/kubernetes_node_ready.md
@@ -1,0 +1,8 @@
+---
+title: kubernetes.node_ready
+brief: Whether this node is ready (1), not ready (0) or in an unknown state (-1)
+metric_type: gauge
+---
+### kubernetes.node_ready
+
+Whether this node is ready (1), not ready (0) or in an unknown state (-1)

--- a/signalfx-agent/kubernetes/signalfx-agent.daemonset.yml
+++ b/signalfx-agent/kubernetes/signalfx-agent.daemonset.yml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
     name: signalfx-agent
     labels:
-        version: 2.2.1
+        version: 2.2.2
         app: signalfx-agent
 spec:
     selector:
@@ -13,13 +13,13 @@ spec:
         metadata:
             labels:
                 app: signalfx-agent
-                version: 2.2.1
+                version: 2.2.2
         spec:
             hostNetwork: true
             restartPolicy: Always
             containers:
             - name: signalfx-agent
-              image: quay.io/signalfx/signalfx-agent:2.2.1
+              image: quay.io/signalfx/signalfx-agent:2.2.2
               securityContext:
                 privileged: true
               command:


### PR DESCRIPTION
Metric doc is for new K8s node readiness metric I added