### PR TITLE
Fixing data_signature of new agent

### DIFF
--- a/signalfx-agent/meta.yaml
+++ b/signalfx-agent/meta.yaml
@@ -6,6 +6,6 @@
   "sort_order": 0,
   "logo_large": "/images/repos/collectd/img/integration_smartagent@2x.png",
   "logo_small": "/images/repos/collectd/img/integration_smartagent.png",
-  "data_signature": "plugin:\"signalfx-metadata\"",
+  "data_signature": "_exists_:signalfx_agent",
   "in_app_categories": ["essential", "servicesMonitored"]
 }


### PR DESCRIPTION
This dimension is on the `gauge.sf.host-plugin_uptime` metric for only the new agent.  This doesn't seem to work quite right in lab but at least it doesn't show a check when you only have the old collectd installed.