### PR TITLE
Corrected link to kubernetes setup instructions

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -8,7 +8,7 @@ Metadata associated with the Kubernetes integration can be found [here](https://
 
 ### DESCRIPTION
 
-See the <a target="_blank" href="https://docs.signalfx.com/en/latest/integrations/kubernetes-quickstart.html">Quick Start Guide</a> to start using our Kubernetes integration.
+See the <a target="_blank" href="https://docs.signalfx.com/en/latest/integrations/agent/kubernetes-setup.html">Kubernetes setup instructions</a> to start using our Kubernetes integration.
 
 ### METRICS
 


### PR DESCRIPTION
Instructions have been moved to be under the Smart Agent heading; source is now at https://github.com/signalfx/signalfx-agent/blob/master/docs/kubernetes-setup.md