### PR TITLE
adding missing consul metric doc

### DIFF
--- a/collectd-consul/docs/gauge.consul.consul.rpc.query.md
+++ b/collectd-consul/docs/gauge.consul.consul.rpc.query.md
@@ -1,0 +1,7 @@
+---
+title: Number of RPC Queries
+brief: A general measure of all read volume
+metric_type: gauge
+---
+### Number of RPC Queries
+A general measure of all read volume. This metric has the dimensions `datacenter`, `consul_node` and `consul_mode`.


### PR DESCRIPTION
`gauge.consul.consul.rpc.query.md` was missing from docs but being used in the default dashboard