### PR TITLE
Change URLs from markdown syntax to HTML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Validated Integrations
 
-SignalFx indexes available and validated integrations [here](http://signalfx.github.io). On this page, users can browse available integrations and find the integration that monitors the software they care about. This also provides a single place to view all of the integrations that SignalFx has validated and for which SignalFx has provided built-in content in the SignalFx application. Each integration has a link to the code as well as a Project repository with information on:
+SignalFx indexes available and validated integrations <a target="_blank" href="http://signalfx.github.io">here</a>. On this page, users can browse available integrations and find the integration that monitors the software they care about. This also provides a single place to view all of the integrations that SignalFx has validated and for which SignalFx has provided built-in content in the SignalFx application. Each integration has a link to the code as well as a Project repository with information on:
 
 - How to install, configure and use the integration
 - The metrics that are emitted
@@ -9,10 +9,10 @@ SignalFx indexes available and validated integrations [here](http://signalfx.git
 In order to be added to the integration index, SignalFx validates each integration for stability, scale, and compatibility. If you would like to contribute here is the process:
 
 1. Create and publish a integration for SignalFx.
- 1. We have built an example [collectd-based plugin](https://github.com/signalfx/collectd-example/blob/master/example_plugin.py) to help you get started.
- 1. For other data collector types you'll just need to make sure that you can direct the output to SignalFX and use one of our [supported formats](https://developers.signalfx.com/docs/signalfx-api-overview)
+ 1. We have built an example <a target="_blank" href="https://github.com/signalfx/collectd-example/blob/master/example_plugin.py">collectd-based plugin</a> to help you get started.
+ 1. For other data collector types you'll just need to make sure that you can direct the output to SignalFX and use one of our <a target="_blank" href="https://developers.signalfx.com/docs/signalfx-api-overview">supported formats</a>
 1. Ensure that your plugin meets the validation requirements - more on that below.
-1. Clone [this repository](https://github.com/signalfx/Integrations) locally.
+1. Clone <a target="_blank" href="https://github.com/signalfx/Integrations">this repository</a> locally.
 1. Create a directory in this repository named after your plugin.
 1. Add required documentation content to that directory.
 1. Commit and submit a pull request to this repository. Pull request template will prompt for all required information. When you change or enhance your plugin, send updates through a pull request.
@@ -38,11 +38,11 @@ You're the expert in the software that you wrote the integration for. The goal o
 ### Code Requirements
 Below are requirements for integration code:
 
-1. Include a README file that matches the [prescribed format](https://github.com/signalfx/integrations/blob/master/Example/README.md). This file should contain all the information that a user would need to install, run and derive value from your integration.
+1. Include a README file that matches the <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/Example/README.md">prescribed format</a>. This file should contain all the information that a user would need to install, run and derive value from your integration.
 1. Submit your performance test plan and results.
 1. Make sure that your integration collects all the data that is necessary to monitor the software in question.
   - When deciding which metrics your integration should report, err on the side of a concise list that reports just the important metrics, rather than a longer one that reports everything available. A good model is to separate metrics into those that will be sent by default, and those that are available in "detailed" mode. Use other validated integrations as a guide on what to include.
-1. Include dimensions by adding key-value pairs to metric names. Dimensions can include any context that a user needs to drill down or slice-and-dice metrics through their environment (ex. cluster name, node name, region). Dimensions can capture any important concepts of the software being monitored, such as *queue name* for a message queue or *index name* for a search utility. To read more about dimensions, see SignalFx's data model on [developers.signalfx.io](http://developers.signalfx.io).
+1. Include dimensions by adding key-value pairs to metric names. Dimensions can include any context that a user needs to drill down or slice-and-dice metrics through their environment (ex. cluster name, node name, region). Dimensions can capture any important concepts of the software being monitored, such as *queue name* for a message queue or *index name* for a search utility. To read more about dimensions, see SignalFx's data model on <a target="_blank" href="http://developers.signalfx.io">developers.signalfx.io</a>.
 
 ### Documentation Requirements
 
@@ -53,7 +53,7 @@ Metadata about your integration is stored in the SignalFx integration index to h
 1. Documentation of the metrics emitted by your integration
 1. Screenshots of example charts that show how data from your integration should be used
 
-An example can be found here: [github.com/signalfx/collectd-example](https://github.com/signalfx/collectd-example)
+An example can be found here: <a target="_blank" href="https://github.com/signalfx/collectd-example">github.com/signalfx/collectd-example</a>
 
 #### Structured document (YAML File)
 
@@ -87,14 +87,14 @@ Example:
 
 To help users get up and running quickly, provide a sample configuration for your integration that includes sensible default values and highlights required configuration.
 
-An example of a sample configuration file can be found in in the [Example directory](https://github.com/signalfx/integrations/blob/master/Example/10-example.conf).
+An example of a sample configuration file can be found in in the <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/Example/10-example.conf">Example directory</a>.
 
 #### Metrics and dimensions documentation
 
 To help users make sense of their new data, provide documentation of each metric and dimension that the integration emits, including name, type (counter, gauge, or cumulative counter) and description of what it measures.
 
-An example metrics documentation file can be found in [Example "docs" directory](https://github.com/signalfx/integrations/tree/master/Example/docs).
+An example metrics documentation file can be found in <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/Example/docs">Example "docs" directory</a>.
 
 #### Sample dashboard
 
-Include a dashboard for your users to import into their monitoring solution, so that they can get instant value out of running your integration. SignalFx provides extended trial accounts for plugin developers that you can use to develop your dashboard. [Contact us to learn more](mailto:community@signalfx.com).
+Include a dashboard for your users to import into their monitoring solution, so that they can get instant value out of running your integration. SignalFx provides extended trial accounts for plugin developers that you can use to develop your dashboard. <a target="_blank" href="mailto:community@signalfx.com">Contact us to learn more</a>.

--- a/amq-message-age/README.md
+++ b/amq-message-age/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_activemq.png) ActiveMQ Message Age Listener
 
-Metadata associated with the ActiveMQ message age listener can be found [here](https://github.com/signalfx/integrations/tree/release/amq-message-age). The relevant code for the plugin can be found [here](https://github.com/signalfx/activemq-integration).
+Metadata associated with the ActiveMQ message age listener can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/amq-message-age">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/activemq-integration">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/appdynamics/README.md
+++ b/appdynamics/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/appdynamics/img/integrations_appdynamics.png) AppDynamics   
 
-Metadata associated with the AppDynamics Integration can be found [here](https://github.com/signalfx/integrations/tree/release/appdynamics). The relevant code for the integration can be found [here](https://github.com/signalfx/appd-integration).
+Metadata associated with the AppDynamics Integration can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/appdynamics">here</a>. The relevant code for the integration can be found <a target="_blank" href="https://github.com/signalfx/appd-integration">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/aws-alb/README.md
+++ b/aws-alb/README.md
@@ -36,7 +36,7 @@ SignalFx synthesizes a unique ID for each ALB in the dimension `AWSUniqueId`.
 
 ### METRICS
 
-For more information about the metrics emitted by Application Load Balancing, visit the service's homepage at https://aws.amazon.com/elasticloadbalancing/.
+For more information about the metrics emitted by Application Load Balancing, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/elasticloadbalancing/">https://aws.amazon.com/elasticloadbalancing/</a>.
 
 ### LICENSE
 

--- a/aws-autoscaling/README.md
+++ b/aws-autoscaling/README.md
@@ -29,7 +29,7 @@ SignalFx provides built-in dashboards for this service. Find them on the Dashboa
 
 ### METRICS
 
-For more information about the metrics emitted by AWS Auto Scaling, visit the service's homepage at https://aws.amazon.com/autoscaling/.
+For more information about the metrics emitted by AWS Auto Scaling, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/autoscaling/">https://aws.amazon.com/autoscaling/</a>.
 
 ### LICENSE
 

--- a/aws-cloudfront/README.md
+++ b/aws-cloudfront/README.md
@@ -37,7 +37,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon CloudFront, visit the service's homepage at https://aws.amazon.com/cloudfront/.
+For more information about the metrics emitted by Amazon CloudFront, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/cloudfront/">https://aws.amazon.com/cloudfront/</a>.
 
 ### LICENSE
 

--- a/aws-dynamodb/README.md
+++ b/aws-dynamodb/README.md
@@ -77,7 +77,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon DynamoDB, visit the service's homepage at https://aws.amazon.com/dynamodb/.
+For more information about the metrics emitted by Amazon DynamoDB, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/dynamodb/">https://aws.amazon.com/dynamodb/</a>.
 
 ### LICENSE
 

--- a/aws-ebs/README.md
+++ b/aws-ebs/README.md
@@ -53,7 +53,7 @@ For EBS, SignalFx will scan every volume ID from your AWS account and pull out p
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon Elastic Block Store, visit the service's homepage at https://aws.amazon.com/ebs/.
+For more information about the metrics emitted by Amazon Elastic Block Store, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/ebs/">https://aws.amazon.com/ebs/</a>.
 
 ### LICENSE
 

--- a/aws-ec2/README.md
+++ b/aws-ec2/README.md
@@ -66,11 +66,11 @@ For EC2, SignalFx will scan every instance ID from your AWS account and pull out
 | reservation-id	| aws\_reservation\_id	| ID of the instance’s reservation |
 | root-device-type	| aws\_root\_device\_type	| Type of root device that the instance uses |
 
-For more information about the filters, see http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-DescribeInstances.html.
+For more information about the filters, see <a target="_blank" href="http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-DescribeInstances.html">http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-DescribeInstances.html</a>.
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon EC2, visit the service's homepage at https://aws.amazon.com/ec2/.
+For more information about the metrics emitted by Amazon EC2, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/ec2/">https://aws.amazon.com/ec2/</a>.
 
 ### LICENSE
 

--- a/aws-ecs/README.md
+++ b/aws-ecs/README.md
@@ -10,7 +10,7 @@
 
 Use SignalFx to monitor Amazon EC2 Container Service (ECS) via [Amazon Web Services](https://github.com/signalfx/integrations/tree/master/aws)[](sfx_link:aws).
 
-For greater insight into your ECS environment, SignalFx's Smart Agent can auto-discover services and provide more in-depth metrics about your containers that are running in ECS.  See the [Smart Agent ECS Deployment Guide](https://github.com/signalfx/signalfx-agent/tree/master/deployments/ecs) for instructions on how to deploy the Smart Agent in ECS.
+For greater insight into your ECS environment, SignalFx's Smart Agent can auto-discover services and provide more in-depth metrics about your containers that are running in ECS.  See the <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/deployments/ecs">Smart Agent ECS Deployment Guide</a> for instructions on how to deploy the Smart Agent in ECS.
 #### FEATURES
 
 ##### Built-in dashboards
@@ -45,7 +45,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon EC2 Container Service, visit the service's homepage at https://aws.amazon.com/ecs/.
+For more information about the metrics emitted by Amazon EC2 Container Service, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/ecs/">https://aws.amazon.com/ecs/</a>.
 
 ### LICENSE
 

--- a/aws-elasticache/README.md
+++ b/aws-elasticache/README.md
@@ -44,7 +44,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon ElastiCache, visit the service's homepage at https://aws.amazon.com/elasticache/.
+For more information about the metrics emitted by Amazon ElastiCache, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/elasticache/">https://aws.amazon.com/elasticache/</a>.
 
 ### LICENSE
 

--- a/aws-elb/README.md
+++ b/aws-elb/README.md
@@ -44,7 +44,7 @@ For ELB, SignalFx will scan every load balancer name from your AWS account and p
 
 ### METRICS
 
-For more information about the metrics emitted by Elastic Load Balancing, visit the service's homepage at https://aws.amazon.com/elasticloadbalancing/.
+For more information about the metrics emitted by Elastic Load Balancing, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/elasticloadbalancing/">https://aws.amazon.com/elasticloadbalancing/</a>.
 
 ### LICENSE
 

--- a/aws-kinesis/README.md
+++ b/aws-kinesis/README.md
@@ -38,7 +38,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by AWS Kinesis, visit the service's homepage at https://aws.amazon.com/kinesis/.
+For more information about the metrics emitted by AWS Kinesis, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/kinesis/">https://aws.amazon.com/kinesis/</a>.
 
 ### LICENSE
 

--- a/aws-lambda/README.md
+++ b/aws-lambda/README.md
@@ -99,7 +99,7 @@ The Lambda wrappers add several dimensions to data points sent to SignalFx. Thes
 
 #### CloudWatch
 
-For more information about the metrics emitted by Lambda, see the documentation at https://docs.signalfx.com/en/latest/integrations/aws-info.html#lambda-metadata.
+For more information about the metrics emitted by Lambda, see the documentation at <a target="_blank" href="https://docs.signalfx.com/en/latest/integrations/aws-info.html#lambda-metadata">https://docs.signalfx.com/en/latest/integrations/aws-info.html#lambda-metadata</a>.
 
 ### LICENSE
 

--- a/aws-opsworks/README.md
+++ b/aws-opsworks/README.md
@@ -38,7 +38,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by AWS OpsWorks, visit the service's homepage at https://aws.amazon.com/opsworks/.
+For more information about the metrics emitted by AWS OpsWorks, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/opsworks/">https://aws.amazon.com/opsworks/</a>.
 
 ### LICENSE
 

--- a/aws-rds/README.md
+++ b/aws-rds/README.md
@@ -34,7 +34,7 @@ SignalFx supports an integration with <a target="_blank" href="http://docs.aws.a
 
 You can choose to deploy the function either from the Serverless Application Repository (recommended) or from source. Choose a deployment method and follow the steps below to encrypt your SignalFx access token, customize the metrics that will be sent to SignalFx, and create and deploy the new function. 
 
-Before you begin, you must enable the Enhanced Monitoring option for the RDS instances you want to monitor using this integration. [Click here for instructions on enabling Enhanced Monitoring](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html).
+Before you begin, you must enable the Enhanced Monitoring option for the RDS instances you want to monitor using this integration. <a target="_blank" href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html">Click here for instructions on enabling Enhanced Monitoring</a>.
 
 ##### Note: Encryption of your SignalFx access token
 This Lambda function uses your SignalFx access token to send metrics to SignalFx, as an environment variable to the function. While Lambda encrypts all environment variables at rest and decrypts them upon invocation, AWS recommends that all sensitive information such as access tokens be encrypted using a KMS key before function deployment, and decrypted at runtime within the code. 
@@ -48,12 +48,12 @@ Both procedures below include instructions for using either an encrypted or non-
 #### Deploying through the Serverless Application Repository
 
 ##### 1. Set up an encryption key and encrypt your access token (if desired)
-Only follow this step if you chose to manually encrypt your access token. Either create a new KMS encryption key or select a preexisting one. **The key must be in the same availability zone as the RDS instances you are monitoring.** You can create and manage encryption keys from IAM in the AWS management console. Documentation on KMS encryption from the CLI can be found [here](http://docs.aws.amazon.com/cli/latest/reference/kms/encrypt.html). Make sure you have access to the cipher text output by the encryption as well as the key id of the encryption key you used.
+Only follow this step if you chose to manually encrypt your access token. Either create a new KMS encryption key or select a preexisting one. **The key must be in the same availability zone as the RDS instances you are monitoring.** You can create and manage encryption keys from IAM in the AWS management console. Documentation on KMS encryption from the CLI can be found <a target="_blank" href="http://docs.aws.amazon.com/cli/latest/reference/kms/encrypt.html">here</a>. Make sure you have access to the cipher text output by the encryption as well as the key id of the encryption key you used.
 
 ##### 2. Create the Lambda function
 Click `Create Function` from the list of Lambda functions in your AWS console. Make sure you are in the intended availability zone. Select the `Serverless Application Repository` option in the upper right hand corner. Search for `signalfx rds` and choose the appropriate entry based on whether you encrypted your access token.
 
-To access the templates directly, find the template for encrypted access tokens [here](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:134183635603:applications~signalfx-enhanced-rds-metrics-encrypted). The template for non-encrypted access tokens is [here](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:134183635603:applications~signalfx-enhanced-rds-metrics).
+To access the templates directly, find the template for encrypted access tokens <a target="_blank" href="https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:134183635603:applications~signalfx-enhanced-rds-metrics-encrypted">here</a>. The template for non-encrypted access tokens is <a target="_blank" href="https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:134183635603:applications~signalfx-enhanced-rds-metrics">here</a>.
 
 ##### 3. Fill out application parameters
 Under `Configure application parameters`, choose a name for your function, and fill out the fields accordingly.
@@ -87,10 +87,10 @@ That's it! Your metrics are on the way to SignalFx ingest!
 The execution role just needs basic Lambda execution permissions and KMS decrypt permissions (if you wish to encrypt your SignalFx access token). If you don't want to create one, you can select from a list of templates when you create the lambda function.
 
 ##### 2. Set up an encryption key and encrypt access token
-Only follow this step if you chose to encrypt your access token. Either create a new KMS encryption key or select a preexisting one. **The key must be in the same availability zone as the RDS instances you are monitoring.** You can create and manage encryption keys from IAM in the AWS management console. Documentation on KMS encryption from the CLI can be found [here](http://docs.aws.amazon.com/cli/latest/reference/kms/encrypt.html). Make sure you have access to the cipher text output by the encryption as well as the key id of the encryption key you used.
+Only follow this step if you chose to encrypt your access token. Either create a new KMS encryption key or select a preexisting one. **The key must be in the same availability zone as the RDS instances you are monitoring.** You can create and manage encryption keys from IAM in the AWS management console. Documentation on KMS encryption from the CLI can be found <a target="_blank" href="http://docs.aws.amazon.com/cli/latest/reference/kms/encrypt.html">here</a>. Make sure you have access to the cipher text output by the encryption as well as the key id of the encryption key you used.
 
 ##### 3. Clone the source repo and build the deployment package
-You can find the repo [here](https://github.com/signalfx/enhanced-rds-monitoring).
+You can find the repo <a target="_blank" href="https://github.com/signalfx/enhanced-rds-monitoring">here</a>.
 Once you have cloned the repo:
 ```
 $ cd enhanced-rds-monitoring
@@ -124,7 +124,7 @@ Click `Save`, and once the trigger is enabled, your function will start sending 
 
 #### Metric groups collected by this integration
 
-The following metric groups are collected by this integration. To collect all of them, use `All` at configuration time. To select a subset, choose metric groups by name. You can find documentation on the available metrics [here](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuid/USER_Monitoring.OS.html).
+The following metric groups are collected by this integration. To collect all of them, use `All` at configuration time. To select a subset, choose metric groups by name. You can find documentation on the available metrics <a target="_blank" href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuid/USER_Monitoring.OS.html">here</a>.
 
 **Metric Groups (except for SQLServer)**
 - cpuUtilization
@@ -159,7 +159,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon Relational Database Service, visit the service's homepage at https://aws.amazon.com/rds/.
+For more information about the metrics emitted by Amazon Relational Database Service, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/rds/">https://aws.amazon.com/rds/<a>.
 
 ### LICENSE
 

--- a/aws-redshift/README.md
+++ b/aws-redshift/README.md
@@ -34,7 +34,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon Redshift, visit the service's homepage at https://aws.amazon.com/redshift/.
+For more information about the metrics emitted by Amazon Redshift, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/redshift/">https://aws.amazon.com/redshift/</a>.
 
 ### LICENSE
 

--- a/aws-route53/README.md
+++ b/aws-route53/README.md
@@ -38,7 +38,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon Route 53, visit the service's homepage at https://aws.amazon.com/route53/.
+For more information about the metrics emitted by Amazon Route 53, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/route53/">https://aws.amazon.com/route53/</a>.
 
 ### LICENSE
 

--- a/aws-sns/README.md
+++ b/aws-sns/README.md
@@ -32,7 +32,7 @@ SignalFx provides a built-in dashboard for this service, as shown below.
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon Simple Notification Service, visit the service's homepage at https://aws.amazon.com/sns/.
+For more information about the metrics emitted by Amazon Simple Notification Service, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/sns/">https://aws.amazon.com/sns/</a>.
 
 ### LICENSE
 

--- a/aws-sqs/README.md
+++ b/aws-sqs/README.md
@@ -38,7 +38,7 @@ SignalFx provides built-in dashboards for this service. Examples are shown below
 
 ### METRICS
 
-For more information about the metrics emitted by Amazon Simple Queue Service, visit the service's homepage at https://aws.amazon.com/sqs/.
+For more information about the metrics emitted by Amazon Simple Queue Service, visit the service's homepage at <a target="_blank" href="https://aws.amazon.com/sqs/">https://aws.amazon.com/sqs/</a>.
 
 ### LICENSE
 

--- a/azure-app-service/README.md
+++ b/azure-app-service/README.md
@@ -66,7 +66,7 @@ To access this integration, [connect to Microsoft Azure](https://github.com/sign
 
 ### METRICS
 
-For more information about the metrics emitted by Azure App Service, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftwebsites-excluding-functions).
+For more information about the metrics emitted by Azure App Service, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftwebsites-excluding-functions">here</a>.
 
 ### LICENSE
 

--- a/azure-batch/README.md
+++ b/azure-batch/README.md
@@ -76,7 +76,7 @@ To access this integration, [connect to Microsoft Azure](https://github.com/sign
 
 ### METRICS
 
-For more information about the metrics emitted by Azure Batch, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftbatchbatchaccounts).
+For more information about the metrics emitted by Azure Batch, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftbatchbatchaccounts">here</a>.
 
 ### LICENSE
 

--- a/azure-event-hubs/README.md
+++ b/azure-event-hubs/README.md
@@ -104,7 +104,7 @@ To access this integration, [connect to Microsoft Azure](https://github.com/sign
 
 ### METRICS
 
-For more information about the metrics emitted by Azure Event Hubs, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsofteventhubnamespaces).
+For more information about the metrics emitted by Azure Event Hubs, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsofteventhubnamespaces">here</a>.
 
 ### LICENSE
 

--- a/azure-functions/README.md
+++ b/azure-functions/README.md
@@ -85,7 +85,7 @@ The Azure Function wrappers add several dimensions to data points sent to Signal
 
 #### Azure Monitor
 
-For more information about the metrics emitted by Azure Functions, see the documentation at https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.microsoft.azure.html.
+For more information about the metrics emitted by Azure Functions, see the documentation at <a target="_blank" href="https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.microsoft.azure.html">https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.microsoft.azure.html</a>.
 
 ### LICENSE
 

--- a/azure-logic-app/README.md
+++ b/azure-logic-app/README.md
@@ -96,7 +96,7 @@ To access this integration, [connect to Microsoft Azure](https://github.com/sign
 
 ### METRICS
 
-For more information about the metrics emitted by Azure Logic Apps, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftlogicworkflows).
+For more information about the metrics emitted by Azure Logic Apps, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftlogicworkflows">here</a>.
 
 ### LICENSE
 

--- a/azure-redis/README.md
+++ b/azure-redis/README.md
@@ -129,7 +129,7 @@ To access this integration, [connect to Microsoft Azure](https://github.com/sign
 
 ### METRICS
 
-For more information about the metrics emitted by Azure Redis Cache, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftcacheredis).
+For more information about the metrics emitted by Azure Redis Cache, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftcacheredis">here</a>.
 
 ### LICENSE
 

--- a/azure-sql-databases/README.md
+++ b/azure-sql-databases/README.md
@@ -69,7 +69,7 @@ To access this integration, [connect to Microsoft Azure](https://github.com/sign
 
 ### METRICS
 
-For more information about the metrics emitted by Azure SQL Database, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftsqlserversdatabases).
+For more information about the metrics emitted by Azure SQL Database, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftsqlserversdatabases">here</a>.
 
 ### LICENSE
 

--- a/azure-sql-elasticpools/README.md
+++ b/azure-sql-elasticpools/README.md
@@ -58,7 +58,7 @@ To access this integration, [connect to Microsoft Azure](https://github.com/sign
 
 ### METRICS
 
-For more information about the metrics emitted by Azure SQL Elastic Pools, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftsqlserverselasticpools).
+For more information about the metrics emitted by Azure SQL Elastic Pools, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftsqlserverselasticpools">here</a>.
 
 ### LICENSE
 

--- a/azure-storage/README.md
+++ b/azure-storage/README.md
@@ -95,7 +95,7 @@ To access this integration, [connect to Microsoft Azure](https://github.com/sign
 
 ### METRICS
 
-For more information about the metrics emitted by Azure Storage, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftstoragestorageaccounts).
+For more information about the metrics emitted by Azure Storage, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftstoragestorageaccounts">here</a>.
 
 ### LICENSE
 

--- a/azure-vm/README.md
+++ b/azure-vm/README.md
@@ -125,7 +125,7 @@ The above charts are applicable to all Azure Virtual Machines. The following two
 
 ### METRICS
 
-For more information about the metrics emitted by Azure Virtual Machines, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftcomputevirtualmachines).
+For more information about the metrics emitted by Azure Virtual Machines, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftcomputevirtualmachines">here</a>.
 
 ### LICENSE
 

--- a/azure-vmscaleset/README.md
+++ b/azure-vmscaleset/README.md
@@ -121,7 +121,7 @@ The above charts are applicable to all Azure VM Scale Sets. The following two ch
 
 ### METRICS
 
-For more information about the metrics emitted by Azure Virtual Machine Scale Sets, visit [here](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftbatchbatchaccounts).
+For more information about the metrics emitted by Azure Virtual Machine Scale Sets, visit <a target="_blank" href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftbatchbatchaccounts">here</a>.
 
 ### LICENSE
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -23,7 +23,7 @@ To connect SignalFx to Microsoft Azure, you’ll create a new Application in Azu
 
 ### USAGE
 
-See [our detailed Azure integration guide](https://docs.signalfx.com/en/latest/integrations/azure-info.html) for more information.
+See <a target="_blank" href="https://docs.signalfx.com/en/latest/integrations/azure-info.html">our detailed Azure integration guide</a> for more information.
 
 ### METRICS
 

--- a/cloudfoundry-generic/README.md
+++ b/cloudfoundry-generic/README.md
@@ -1,6 +1,6 @@
 # ![](././img/integrations_cloudfoundry.png) Cloud Foundry
 
-Metadata associated with the **Cloud Foundry Integration** can be found [here](https://github.com/signalfx/integrations/tree/release/cloudfoundry-generic). The relevant code for the integration can be found [here](https://github.com/search?q=topic%3Acloud-foundry+org%3Asignalfx+fork%3Atrue).
+Metadata associated with the **Cloud Foundry Integration** can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/cloudfoundry-generic">here</a>. The relevant code for the integration can be found <a target="_blank" href="https://github.com/search?q=topic%3Acloud-foundry+org%3Asignalfx+fork%3Atrue">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/cloudfoundry-pivotal/README.md
+++ b/cloudfoundry-pivotal/README.md
@@ -1,6 +1,6 @@
 # ![](././img/integrations_pivotalcloudfoundry.png) Pivotal Cloud Foundry
 
-Metadata associated with the **Pivotal Cloud Foundry Integration** can be found [here](https://github.com/signalfx/integrations/tree/release/cloudfoundry-pivotal). The relevant code for the integration can be found [here](https://github.com/signalfx/cloudfoundry-integration).
+Metadata associated with the **Pivotal Cloud Foundry Integration** can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/cloudfoundry-pivotal">here</a>. The relevant code for the integration can be found <a target="_blank" href="https://github.com/signalfx/cloudfoundry-integration">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-activemq/README.md
+++ b/collectd-activemq/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_activemq.png) ActiveMQ
 
-Metadata associated with SignalFx's integration with ActiveMQ can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-activemq). The relevant code for the plugin can be found [here](https://github.com/signalfx/activemq-integration).
+Metadata associated with SignalFx's integration with ActiveMQ can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-activemq">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/activemq-integration">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-aggregation/README.md
+++ b/collectd-aggregation/README.md
@@ -8,7 +8,7 @@
 
 ### DESCRIPTION
 
-Use the [aggregation](https://collectd.org/wiki/index.php/Plugin:Aggregation) plugin to aggregate metrics. This plugin provides aggregates, by default average and summary.
+Use the <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Aggregation">aggregation</a> plugin to aggregate metrics. This plugin provides aggregates, by default average and summary.
 
 ### REQUIREMENTS AND DEPENDENCIES
 
@@ -19,7 +19,7 @@ Use the [aggregation](https://collectd.org/wiki/index.php/Plugin:Aggregation) pl
 
 
 ### CONFIGURATION
-By default the CPU plugin will assign each CPU a number and use that as the plugin\_instance. This gives a very detailed report of CPU usage, but it is not generally useful. Use the [following configuration](https://github.com/signalfx/Integrations/blob/master/collectd-aggregation/10-aggregation-cpu.conf) to aggregate CPU metrics.
+By default the CPU plugin will assign each CPU a number and use that as the plugin\_instance. This gives a very detailed report of CPU usage, but it is not generally useful. Use the <a target="_blank" href="https://github.com/signalfx/Integrations/blob/master/collectd-aggregation/10-aggregation-cpu.conf">following configuration</a> to aggregate CPU metrics.
 
 
 ### METRICS

--- a/collectd-apache/README.md
+++ b/collectd-apache/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-apache/img/integrations_apache.png) Apache
 
-Metadata associated with the Apache collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-apache). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/apache.c).
+Metadata associated with the Apache collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-apache">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/apache.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-cassandra/README.md
+++ b/collectd-cassandra/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_cassandra.png) Cassandra
 
- Metadata associated with SignalFx's Cassandra integration with collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-cassandra). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/java.c).
+ Metadata associated with SignalFx's Cassandra integration with collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-cassandra">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/java.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-consul/README.md
+++ b/collectd-consul/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_consul.png) Consul
 
-Metadata associated with the consul plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-consul). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-consul).
+Metadata associated with the consul plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-consul">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-consul">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-couchbase/README.md
+++ b/collectd-couchbase/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-couchbase/img/integrations_couchbase.png) Couchbase
 
-Metadata associated with SignalFx's Couchbase integration can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-couchbase). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-couchbase).
+Metadata associated with SignalFx's Couchbase integration can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-couchbase">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-couchbase">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-couchdb/README.md
+++ b/collectd-couchdb/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_couchdb.png) CouchDB
 
-Metadata associated with the couchdb plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-couchdb). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-couchdb).
+Metadata associated with the couchdb plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-couchdb">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-couchdb">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-curl-json/README.md
+++ b/collectd-curl-json/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) cURL-JSON Plugin
 
-Metadata associated with the cURL-JSON collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-curl-json). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/curl_json.c).
+Metadata associated with the cURL-JSON collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-curl-json">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/curl_json.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -11,7 +11,7 @@ Metadata associated with the cURL-JSON collectd plugin can be found [here](https
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:cURL-JSON):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:cURL-JSON">collectd wiki</a>:
 
 The cURL-JSON plugin queries JavaScript Object Notation (JSON) data using the cURL library and parses it according to the user's configuration using Yet Another JSON Library (YAJL). This can be used to query statistics information from a CouchDB instance, for example.
 
@@ -25,12 +25,12 @@ This plugin requires:
 
 ### INSTALLATION
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:cURL-JSON):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:cURL-JSON">collectd wiki</a>:
 
 This plugin is a generic plugin, i.e. it cannot work without configuration, because there is no reasonable default behavior. Please read the [Plugin curl\_json section](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_curl_json) of the collectd.conf manual page for an in-depth description of the plugin's configuration.
 
@@ -40,4 +40,4 @@ There are many potential uses for the cURL-JSON plugin. One example is for gathe
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/curl_json.c).
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/curl_json.c">in the header of the plugin</a>.

--- a/collectd-df/README.md
+++ b/collectd-df/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) DF (Disk Free)
 
-Metadata associated with the df collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-df). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/df.c).
+Metadata associated with the df collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-df">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/df.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -12,7 +12,7 @@ Metadata associated with the df collectd plugin can be found [here](https://gith
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:DF):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:DF">collectd wiki</a>:
 
 > The DF plugin collects file system usage information, i. e. basically how much space on a mounted partition is used and how much is available. It's named after and very similar to the df(1) UNIX command that's been around forever.
 However, not all "partitions" are of interest. For example /proc and /dev usually don't get filled and their "size" doesn't make a lot of sense. That's why the DF plugin offers to select only specific devices, mount points or filesystem types.
@@ -33,12 +33,12 @@ for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
 
-Configuration for this plugin is kept in the main [collectd.conf](https://github.com/signalfx/integrations/blob/master/collectd/collectd.conf) file.
+Configuration for this plugin is kept in the main <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd/collectd.conf">collectd.conf</a> file.
 
 | Configuration Option | Type | Definition |
 |----------------------|------|------------|
@@ -55,7 +55,7 @@ Configuration for this plugin is kept in the main [collectd.conf](https://github
 
 The primary use of this plugin is to track the available space on the systems filesystems. This can be used to set alerts and thresholds to avoid a filesystem from being filled to capacity.
 
-The [SignalFx collectd plugin](https://github.com/signalfx/integrations/tree/master/signalfx-metadata) computes aggregated utilization metrics based on the output of this plugin you can learn more by looking at the [metrics for the plugin](https://github.com/signalfx/integrations/tree/master/signalfx-metadata/docs/disk.utilization.md).
+The <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/signalfx-metadata">SignalFx collectd plugin</a> computes aggregated utilization metrics based on the output of this plugin you can learn more by looking at the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/signalfx-metadata/docs/disk.utilization.md">metrics for the plugin</a>.
 
 ### METRICS
 
@@ -63,4 +63,4 @@ For documentation of the metrics and dimensions emitted by this plugin, [click h
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/df.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/df.c">in the header of the plugin</a>

--- a/collectd-disk/README.md
+++ b/collectd-disk/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) Disk
 
-Metadata associated with the Disk collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-disk). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/disk.c).
+Metadata associated with the Disk collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-disk">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/disk.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -12,7 +12,7 @@ Metadata associated with the Disk collectd plugin can be found [here](https://gi
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:Disk):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Disk">collectd wiki</a>:
 
 The Disk plugin collects performance statistics of hard-disks and, where supported, partitions. While the “octets” and “operations” are quite straight forward, the other two datasets need a little explanation:
  * `merged` are the number of operations, that could be merged into other, already queued operations, i. e. one physical disk access served two or more logical operations. Of course, the higher that number, the better.
@@ -21,7 +21,7 @@ Since 5.5 there are also additional metrics on the Linux platform:
  * `io_time` - time spent doing I/Os (ms). You can treat this metric as a device load percentage (Value of 1 sec time spent matches 100% of load).
  * `weighted_io_time` - measure of both I/O completion time and the backlog that may be accumulating.
  * `pending_operations` - shows queue size of pending I/O operations.
-For details about these metrics you can also read [kernel documentation](https://www.kernel.org/doc/Documentation/iostats.txt) (Explanations of fields "Field 9", "Field 10" and "Field 11").
+For details about these metrics you can also read <a target="_blank" href="https://www.kernel.org/doc/Documentation/iostats.txt">kernel documentation</a> (Explanations of fields "Field 9", "Field 10" and "Field 11").
 
 ### REQUIREMENTS AND DEPENDENCIES
 
@@ -39,7 +39,7 @@ for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
@@ -57,7 +57,7 @@ The following configuration options are *optional*. You may specify them in the 
 
 The primary use of this plugin is to track the available space on the systems disks. This can be used to set alerts and thresholds to avoid a disks from being filled to capacity.
 
-The [SignalFx collectd plugin](https://github.com/signalfx/integrations/tree/master/signalfx-metadata) computes aggregated utilization metrics based on the output of this plugin you can learn more by looking at the [metrics for the plugin](https://github.com/signalfx/integrations/tree/master/signalfx-metadata/docs).
+The <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/signalfx-metadata">SignalFx collectd plugin</a> computes aggregated utilization metrics based on the output of this plugin you can learn more by looking at the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/signalfx-metadata/docs">metrics for the plugin</a>.
 
 ### METRICS
 
@@ -65,4 +65,4 @@ For documentation of the metrics and dimensions emitted by this plugin, [click h
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/disk.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/disk.c">in the header of the plugin</a>

--- a/collectd-docker/README.md
+++ b/collectd-docker/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-docker/img/integrations_docker.png) Docker
 
-Metadata associated with the Docker plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-docker). The relevant code for the plugin can be found [here](https://github.com/signalfx/docker-collectd-plugin).
+Metadata associated with the Docker plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-docker">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/docker-collectd-plugin">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-elasticsearch/README.md
+++ b/collectd-elasticsearch/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-elasticsearch/img/integrations_elasticsearch.png) Elasticsearch
 
-Metadata associated with the Elasticsearch collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-elasticsearch). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-elasticsearch).
+Metadata associated with the Elasticsearch collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-elasticsearch">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-elasticsearch">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -20,7 +20,7 @@ Use this plugin to monitor the following types of information from an Elasticsea
   * per-index statistics
   * cluster statistics
 
-Original Elasticsearch Documentation https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+Original Elasticsearch Documentation <a target="_blank" href="https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html<a/>
 
 #### FEATURES
 

--- a/collectd-etcd/README.md
+++ b/collectd-etcd/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_etcd.png) etcd
 
-Metadata associated with the etcd plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-etcd). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-etcd).
+Metadata associated with the etcd plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-etcd">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-etcd">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-genericjmx/README.md
+++ b/collectd-genericjmx/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) GenericJMX collectd Plugin
 
-Metadata associated with the GenericJMX collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-genericjmx). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/bindings/java/org/collectd/java/GenericJMX.java).
+Metadata associated with the GenericJMX collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-genericjmx">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/bindings/java/org/collectd/java/GenericJMX.java">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -12,7 +12,7 @@ Metadata associated with the GenericJMX collectd plugin can be found [here](http
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:GenericJMX):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:GenericJMX">collectd wiki</a>:
 
 > The GenericJMX plugin reads Managed Beans (MBeans) from an MBeanServer using JMX. The plugin is written in Java and requires the [Java plugin](https://github.com/signalfx/integrations/tree/master/collectd-java)[](sfx_link:collectd-java) to function.
 
@@ -44,7 +44,7 @@ well, but consult the Smart Agent repo's docs for the exact schema.**
     * Ubuntu 12.04, 14.04, 16.04 & Debian 7, 8:
         - This plugin is included with [SignalFx's collectd package](https://support.signalfx.com/hc/en-us/articles/208080123).
 
-2. Download SignalFx's sample JMX configuration file [20-javageneric.conf](https://github.com/signalfx/integrations/blob/master/collectd-genericjmx/20-javageneric.conf)
+2. Download SignalFx's sample JMX configuration file <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-genericjmx/20-javageneric.conf">20-javageneric.conf</a>
 
 3. Modify the configuration file providing values that make sense for your environment, as described [below](#configuration).
 
@@ -59,7 +59,7 @@ collectd will be ready to be configured for your Java-based application.
 
 ### CONFIGURATION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:GenericJMX):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:GenericJMX">collectd wiki</a>:
 
 > The configuration of the GenericJMX plugin consists of two blocks:
 > * _MBean blocks_ that define a mapping of MBean attributes to the “types” used by collectd
@@ -74,13 +74,13 @@ The following options are recognized within MBean blocks:
 
 | configuration option | type | definition |
 | ---------------------|------------|---------------|
-|ObjectName | pattern | Sets the pattern which is used to retrieve MBeans from the MBeanServer. If more than one MBean is returned you should use the InstanceFrom option (see below) to make the [identifiers](https://collectd.org/wiki/index.php/Identifier) unique. See also: [ObjectName](http://java.sun.com/javase/6/docs/api/javax/management/ObjectName.html).|
+|ObjectName | pattern | Sets the pattern which is used to retrieve MBeans from the MBeanServer. If more than one MBean is returned you should use the InstanceFrom option (see below) to make the <a target="_blank" href="https://collectd.org/wiki/index.php/Identifier">identifiers</a> unique. See also: <a target="_blank" href="http://java.sun.com/javase/6/docs/api/javax/management/ObjectName.html">ObjectName</a>.|
 |InstancePrefix| prefix| Prefixes the generated plugin instance with prefix. (optional)|
 |InstanceFrom| property| The object names used by JMX to identify MBeans include so called “properties” which are basically key-value-pairs. If the given object name is not unique and multiple MBeans are returned, the values of those properties usually differ. You can use this option to build the plugin instance from the appropriate property values. This option is optional and may be repeated to generate the plugin instance from multiple property values.|
 
 > `<value />` blocks
 
-> The value blocks map one or more attributes of an MBean to a [value list](https://collectd.org/wiki/index.php/Value_list) in _collectd_. **There must be at least one `<value />` block within each MBean block.**
+> The value blocks map one or more attributes of an MBean to a <a target="_blank" href="https://collectd.org/wiki/index.php/Value_list">value list</a> in _collectd_. **There must be at least one `<value />` block within each MBean block.**
 
 | configuration option | type | definition |
 | ---------------------|------------|---------------|
@@ -96,8 +96,8 @@ The following options are recognized within MBean blocks:
 
 | configuration option | type | definition |
 | ---------------------|------------|---------------|
-| Host | name | Host name used when dispatching the values to collectd. See [naming schema](https://collectd.org/wiki/index.php/Naming_schema) for details. The option sets this field only, it is not used to connect to anything and doesn't need to be a real, resolvable name. |
-| ServiceURL | URL | Specifies how the MBeanServer can be reached. Any string accepted by the JMXServiceURL is valid. See also: [JMXServiceURL](http://java.sun.com/javase/6/docs/api/javax/management/remote/JMXServiceURL.html) |
+| Host | name | Host name used when dispatching the values to collectd. See <a target="_blank" href="https://collectd.org/wiki/index.php/Naming_schema">naming schema</a> for details. The option sets this field only, it is not used to connect to anything and doesn't need to be a real, resolvable name. |
+| ServiceURL | URL | Specifies how the MBeanServer can be reached. Any string accepted by the JMXServiceURL is valid. See also: <a target="_blank" href="http://java.sun.com/javase/6/docs/api/javax/management/remote/JMXServiceURL.html">JMXServiceURL</a> |
 | User | name | Use name to authenticate to the server. If not configured, “monitorRole” will be used. |
 | Password | password | Use password to authenticate to the server. If not given, unauthenticated access is used. |
 | InstancePrefix | prefix | Prefixes the generated plugin instance with prefix. If a second InstancePrefix is specified in a referenced MBean block, the prefix specified in the Connection block will appear at the beginning of the plugin instance, the prefix specified in the MBean block will be appended to it. (optional, since version 5.0) |
@@ -105,7 +105,7 @@ The following options are recognized within MBean blocks:
 
 ### USAGE
 
-The GenericJMX collectd plugin by itself gathers generic Java metrics. By default this plugin will collect the following metrics when using the [default configuration](https://github.com/signalfx/integrations/blob/master/collectd-genericjmx/20-javageneric.conf):
+The GenericJMX collectd plugin by itself gathers generic Java metrics. By default this plugin will collect the following metrics when using the <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-genericjmx/20-javageneric.conf">default configuration</a>:
 
 | configuration option | type | definition |
 | ---------------------|------------|---------------|

--- a/collectd-hadoop/README.md
+++ b/collectd-hadoop/README.md
@@ -16,17 +16,17 @@ This is the SignalFx Apache Hadoop Integration.  Follow these instructions to in
 The Hadoop collectd plugin and JMX plugin are not dependent on each other, however not installing both will cause some of the SignalFx built-in dashboard content to not be populated.
 
 The Hadoop collectd plugin will collect metrics from the Resource Manager REST API for the following:
-- [Cluster Metrics](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Metrics_API)
-- [Cluster Scheduler](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Scheduler_API)
-- [Cluster Applications](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API)
-- [Cluster Nodes](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Nodes_API)
-- [MapReduce Jobs](https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapredAppMasterRest.html#Jobs_API)
+- <a target="_blank" href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Metrics_API">Cluster Metrics</a>
+- <a target="_blank" href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Scheduler_API">Cluster Scheduler</a>
+- <a target="_blank" href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API">Cluster Applications</a>
+- <a target="_blank" href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Nodes_API">Cluster Nodes</a>
+- <a target="_blank" href="https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapredAppMasterRest.html#Jobs_API">MapReduce Jobs</a>
 
 The collectd GenericJMX will provide detailed metrics for the following:
-- [DataNode](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-datanode.conf)
-- [NameNode](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-namenode.conf)
-- [Node Manager](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-node-manager.conf)
-- [Resource Manager](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-resource-manager.conf)
+- <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-datanode.conf">DataNode</a>
+- <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-namenode.conf">NameNode</a>
+- <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-node-manager.conf">Node Manager</a>
+- <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-resource-manager.conf">Resource Manager</a>
 
 
 #### Features
@@ -83,13 +83,13 @@ Follow these steps to install this plugin:
 
 1. RHEL/CentOS and Amazon Linux users: Install the [Java plugin for collectd](https://github.com/signalfx/integrations/tree/master/collectd-java)[](sfx_link:collectd-java) if it is not already installed as a part of your collectd installation.
 
-2. Download both parts of the Hadoop collectd plugin: [hadoop_plugin.py](https://github.com/signalfx/collectd-hadoop/blob/master/hadoop_plugin.py) and [metrics.py](https://github.com/signalfx/collectd-hadoop/blob/master/metrics.py)
+2. Download both parts of the Hadoop collectd plugin: <a target="_blank" href="https://github.com/signalfx/collectd-hadoop/blob/master/hadoop_plugin.py">hadoop_plugin.py</a> and <a target="_blank" href="https://github.com/signalfx/collectd-hadoop/blob/master/metrics.py">metrics.py</a>
 
-3. Download SignalFx's example configuration file for the Hadoop collectd Plugin to `/etc/collectd/managed_config`:  [10-hadoop.conf](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/10-hadoop.conf).
+3. Download SignalFx's example configuration file for the Hadoop collectd Plugin to `/etc/collectd/managed_config`:  <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/10-hadoop.conf">10-hadoop.conf</a>.
 
 4. Modify your Hadoop collectd Plugin's configuration file to provide values that make sense for your environment, as described in [Configuration](#configuration), below.
 
-4. For JMX-based metrics, place the [20-datanode.conf](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-datanode.conf), [20-namenode.conf](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-namenode.conf), [20-node-manager.conf](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-node-manager.conf), [20-resource-manager.conf](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-resource-manager.conf) on the correct respective node and/or adjust JMX port & host provided in the conf files.
+4. For JMX-based metrics, place the <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-datanode.conf">20-datanode.conf</a>, <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-namenode.conf">20-namenode.conf</a>, <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-node-manager.conf">20-node-manager.conf</a>, <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/20-resource-manager.conf">20-resource-manager.conf</a> on the correct respective node and/or adjust JMX port & host provided in the conf files.
 
 5. Restart collectd.
 
@@ -117,13 +117,13 @@ SignalFx provides several built-in dashboards for Hadoop YARN, HDFS, and MapRedu
 
 >See the following links for more information about specific metric endpoints:
 
->https://hadoop.apache.org/docs/r2.7.4/hadoop-project-dist/hadoop-common/Metrics.html
+><a target="_blank" href="https://hadoop.apache.org/docs/r2.7.4/hadoop-project-dist/hadoop-common/Metrics.html">https://hadoop.apache.org/docs/r2.7.4/hadoop-project-dist/hadoop-common/Metrics.html</a>
 
->https://hadoop.apache.org/docs/r2.7.4/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html
+><a target="_blank" href="https://hadoop.apache.org/docs/r2.7.4/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html">https://hadoop.apache.org/docs/r2.7.4/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html</a>
 
->https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapredAppMasterRest.html
+><a target="_blank" href="https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapredAppMasterRest.html">https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapredAppMasterRest.html</a>
 
-Using the example configuration file [10-hadoop.conf](https://github.com/signalfx/integrations/blob/master/collectd-hadoop/10-hadoop.conf) as a guide, provide values for the configuration options listed below that make sense for your environment.
+Using the example configuration file <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hadoop/10-hadoop.conf">10-hadoop.conf</a> as a guide, provide values for the configuration options listed below that make sense for your environment.
 
 | Configuration Option | Definition | Example Value |
 | ---------------------|------------|---------------|

--- a/collectd-haproxy/README.md
+++ b/collectd-haproxy/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-haproxy/img/integrations_haproxy.png) HAProxy
 
-Metadata associated with the HAProxy collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-haproxy). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-haproxy).
+Metadata associated with the HAProxy collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-haproxy">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-haproxy">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -23,8 +23,7 @@ Use the <a target="_blank" href="https://github.com/signalfx/collectd-haproxy">c
 
 ### INSTALLATION
 
-**If you are using the new Smart Agent, see the docs for [the collectd/haproxy
-monitor](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd-haproxy.md)
+**If you are using the new Smart Agent, see the docs for <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd-haproxy.md">the collectd/haproxy monitor</a>
 for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 

--- a/collectd-hbase/README.md
+++ b/collectd-hbase/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-hbase/img/integrations_hbase.png) HBase collectd Plugin
 
-Metadata associated with the HBase collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-hbase). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/java.c).
+Metadata associated with the HBase collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-hbase">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/java.c">here</a>.
 
 - [Requirements and Dependencies](#requirements-and-dependencies)
 - [Installation](#installation)
@@ -18,7 +18,7 @@ Metadata associated with the HBase collectd plugin can be found [here](https://g
 
 ### INSTALLATION
 
-1. Install the [Java plugin](https://collectd.org/wiki/index.php/Plugin:GenericJMX).
+1. Install the <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:GenericJMX">Java plugin</a>.
 
     * RHEL/CentOS 6.x & 7.x, and Amazon Linux 2014.09, 2015.03 & 2015.09. Run the following command to install the Java plugin for collectd:
 
@@ -30,11 +30,11 @@ Metadata associated with the HBase collectd plugin can be found [here](https://g
 
 2. Download SignalFx's sample JMX configuration file and sample Cassandra configuration file from the following URLs:
 
-    * [JMX.conf](https://github.com/signalfx/integrations/blob/master/collectd-java/10-jmx.conf)
+    * <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-java/10-jmx.conf">JMX.conf</a>
 
-    * [hbase.conf](https://github.com/signalfx/integrations/blob/master/collectd-hbase/20-hbase.conf)
+    * <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hbase/20-hbase.conf">hbase.conf</a>
 
-3. Modify [hbase.conf](https://github.com/signalfx/integrations/blob/master/collectd-hbase/20-hbase.conf) to provide values that make sense for your environment, as described in the header.
+3. Modify <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-hbase/20-hbase.conf">hbase.conf</a> to provide values that make sense for your environment, as described in the header.
 
     * Add the following lines to /etc/collectd.conf, replacing the example paths with the locations of the configuration files you downloaded in step 2:
 
@@ -51,7 +51,7 @@ Metrics from HBase will begin streaming into SignalFx.
 
 
 
-You must include [JMX.conf](https://github.com/signalfx/integrations/blob/master/collectd-java/10-jmx.conf) this ensures that the Java collectd plugin will properly run prior to loading the Cassandra specific configuration.
+You must include <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-java/10-jmx.conf">JMX.conf</a> this ensures that the Java collectd plugin will properly run prior to loading the Cassandra specific configuration.
 
 | Value | Description |
 |-------|-------------|

--- a/collectd-interface/README.md
+++ b/collectd-interface/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) Interface
 
-Metadata associated with the Interface plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-interface). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/interface.c).
+Metadata associated with the Interface plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-interface">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/interface.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -12,7 +12,7 @@ Metadata associated with the Interface plugin for collectd can be found [here](h
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:Interface):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Interface">collectd wiki</a>:
 
 The Interface plugin collects information about the traffic (octets per second), packets per second and errors of interfaces (of course number of errors during one second). If you're not interested in all interfaces but want to exclude some, or only collect information of some selected interfaces, you can select the “interesting” interfaces using the plugin's configuration.
 
@@ -32,7 +32,7 @@ for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
@@ -50,7 +50,7 @@ The following configuration options are *optional*. You may specify them in the 
 
 The primary use of this plugin is to track the I/O of system interfaces. This is not only valuable data to understand the workloads on specific systems but can be combined with other system and application metrics to identify issues related to network and data I/O traffic.
 
-The [SignalFx collectd plugin](https://github.com/signalfx/integrations/tree/release/signalfx-metadata) computes aggregated utilization metrics based on the output of this plugin you can learn more by looking at the [metrics for the plugin](https://github.com/signalfx/integrations/tree/release/signalfx-metadata/docs).
+The <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/signalfx-metadata">SignalFx collectd plugin</a> computes aggregated utilization metrics based on the output of this plugin you can learn more by looking at the <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/signalfx-metadata/docs">metrics for the plugin</a>.
 
 ### METRICS
 
@@ -58,4 +58,4 @@ For documentation of the metrics and dimensions emitted by this plugin, [click h
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/interface.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/interface.c">in the header of the plugin</a>

--- a/collectd-iostat/README.md
+++ b/collectd-iostat/README.md
@@ -1,6 +1,6 @@
 # IOStat
 
-Metadata associated with the IOStat plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-iostat).  The relevant code for the plugin can be found [here](https://github.com/signalfx/iostat-collectd-python).
+Metadata associated with the IOStat plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-iostat">here</a>.  The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/iostat-collectd-python">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -30,14 +30,14 @@ At this time there are no built in dashboards.  You may find metrics reported by
 
 ### INSTALLATION
 1.  Ensure that sysstat is installed on the host.
-2.  Download the [iostat-collectd-python](https://github.com/signalfx/iostat-collectd-python) Python module.
+2.  Download the <a target="_blank" href="https://github.com/signalfx/iostat-collectd-python">iostat-collectd-python</a> Python module.
 3.  Place the contents of the repo in /usr/share/collectd/iostat-collectd-python
 4.  Download SignalFx’s [sample configuration file](./10-iostat.conf) for this plugin to `/etc/collectd/managed_config`.
 5.  Modify the configuration file to provide values that make sense for your environment, as described in [Configuration](#configuration) below.
 6.  Restart collectd.
 
 ### CONFIGURATION
-Using the example configuration file [10-iostat.conf](https://github.com/signalfx/integrations/tree/master/collectd-iostat/10-iostat.conf) as a guide, provide values for the configuration options listed below that make sense for your environment.
+Using the example configuration file <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd-iostat/10-iostat.conf">10-iostat.conf</a> as a guide, provide values for the configuration options listed below that make sense for your environment.
 
 | configuration option | definition | default value |
 | ---------------------|------------|---------------|

--- a/collectd-java/README.md
+++ b/collectd-java/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_java.png) Java
 
-Metadata associated with the Java plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-java). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/java.c).
+Metadata associated with the Java plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-java">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/java.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-jenkins/README.md
+++ b/collectd-jenkins/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_jenkins.png) Jenkins
 
-This directory consolidates all the metadata associated with the jenkins plugin for collectd. The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-jenkins)
+This directory consolidates all the metadata associated with the jenkins plugin for collectd. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-jenkins">here</a>
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-kafka/README.md
+++ b/collectd-kafka/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-kafka/img/integrations_kafka.png) Kafka
 
-Metadata associated with SignalFx's integration with Kafka can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-kafka). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/java.c).
+Metadata associated with SignalFx's integration with Kafka can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-kafka">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/java.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-kong/README.md
+++ b/collectd-kong/README.md
@@ -1,8 +1,8 @@
 # ![](./img/integrations_kong.png) Kong
 
-Metadata associated with the Kong plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/master/collectd-kong).
+Metadata associated with the Kong plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd-kong">here</a>.
 
-The relevant code for the integration can be found [here](https://github.com/signalfx/collectd-kong) and for its Kong plugin dependency [here](https://github.com/signalfx/kong-plugin-signalfx).
+The relevant code for the integration can be found <a target="_blank" href="https://github.com/signalfx/collectd-kong">here</a> and for its Kong plugin dependency <a target="_blank" href="https://github.com/signalfx/kong-plugin-signalfx">here</a>.
 
 - [Description](#description)
 - [Features](#features)
@@ -16,7 +16,7 @@ The relevant code for the integration can be found [here](https://github.com/sig
 ### DESCRIPTION
 
 The SignalFx Kong collectd plugin provides users with the ability to gather and report their service traffic
-metrics with collectd, in tandem with [kong-plugin-signalfx](https://github.com/signalfx/kong-plugin-signalfx).
+metrics with collectd, in tandem with <a target="_blank" href="https://github.com/signalfx/kong-plugin-signalfx">kong-plugin-signalfx</a>.
 
 This plugin emits metrics for configurable request/response lifecycle groups including:
 
@@ -71,13 +71,13 @@ This plugin requires:
 | Python plugin for collectd | (included with [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd)[](sfx_link:sfxcollectd)) |
 | Python | 2.6+ |
 | Kong | 0.11.2+ |
-| Configured [kong-plugin-signalfx](https://github.com/signalfx/kong-plugin-signalfx) | 0.0.1+ |
+| Configured <a target="_blank" href="https://github.com/signalfx/kong-plugin-signalfx">kong-plugin-signalfx</a> | 0.0.1+ |
 
 ### INSTALLATION
 
-Both the SignalFx Smart Agent and collectd agent report metrics made available by the [kong-plugin-signalfx](https://github.com/signalfx/kong-plugin-signalfx) metric endpoint. Please download and install this Lua module on all Kong servers using its [instructions](https://github.com/signalfx/kong-plugin-signalfx/blob/master/README.md).
+Both the SignalFx Smart Agent and collectd agent report metrics made available by the <a target="_blank" href="https://github.com/signalfx/kong-plugin-signalfx">kong-plugin-signalfx</a> metric endpoint. Please download and install this Lua module on all Kong servers using its <a target="_blank" href="https://github.com/signalfx/kong-plugin-signalfx/blob/master/README.md">instructions</a>.
 
-* If you are using the SignalFx Smart Agent, collectd-kong is already included.  Please see [the monitor documentation](https://github.com/signalfx/signalfx-agent/blob/master/docs/monitors/collectd-kong.md) for configuration instructions.
+* If you are using the SignalFx Smart Agent, collectd-kong is already included.  Please see <a target="_blank" href="https://github.com/signalfx/signalfx-agent/blob/master/docs/monitors/collectd-kong.md">the monitor documentation</a> for configuration instructions.
 
 * If you are using the SignalFx collectd agent follow the steps below.
 
@@ -91,7 +91,7 @@ Both the SignalFx Smart Agent and collectd agent report metrics made available b
 
 ### CONFIGURATION
 
-Using the example configuration file [10-kong.conf](https://github.com/signalfx/integrations/blob/master/collectd-kong/10-kong.conf) as a guide, provide values for the configuration options listed below that make sense for your environment.
+Using the example configuration file <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd-kong/10-kong.conf">10-kong.conf</a> as a guide, provide values for the configuration options listed below that make sense for your environment.
 
 | Configuration option | Definition | Example value |
 | ---------------------|------------|---------------|

--- a/collectd-load/README.md
+++ b/collectd-load/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) Load
 
-Metadata associated with the Load collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-load). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/load.c).
+Metadata associated with the Load collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-load">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/load.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -11,7 +11,7 @@ Metadata associated with the Load collectd plugin can be found [here](https://gi
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:Load):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Load">collectd wiki</a>:
 
 > The Load plugin collects the system load. These numbers give a rough overview over the utilization of a machine, though their meaning is mostly overrated.
 The system load is defined as the number of runnable tasks in the run-queue and is provided by many operating systems as a one, five or fifteen minute average.
@@ -32,7 +32,7 @@ for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
@@ -45,4 +45,4 @@ For documentation of the metrics and dimensions emitted by this plugin, [click h
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/load.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/load.c">in the header of the plugin</a>

--- a/collectd-marathon/README.md
+++ b/collectd-marathon/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-marathon/img/integrations_marathon.png) Marathon
 
-Metadata associated with the Marathon plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-marathon).  The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-marathon).
+Metadata associated with the Marathon plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-marathon">here</a>.  The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-marathon">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-memcached/README.md
+++ b/collectd-memcached/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-memcached/img/integrations_memcached.png) Memcached
 
-Metadata associated with the Memcached plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-memcached). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/memcached.c).
+Metadata associated with the Memcached plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-memcached">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/memcached.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-memory/README.md
+++ b/collectd-memory/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) Memory
 
-Metadata associated with the Memory collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-memory). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/memory.c).
+Metadata associated with the Memory collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-memory">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/memory.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -11,7 +11,7 @@ Metadata associated with the Memory collectd plugin can be found [here](https://
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:Memory):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Memory">collectd wiki</a>:
 
 > The Memory plugin collects physical memory utilization.
 The values are reported by their use by the operating system. Under Linux, the categories are:
@@ -41,7 +41,7 @@ for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
@@ -54,4 +54,4 @@ For documentation of the metrics and dimensions emitted by this plugin, [click h
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/memory.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/memory.c">in the header of the plugin</a>

--- a/collectd-mongodb/README.md
+++ b/collectd-mongodb/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-mongodb/img/integrations_mongodb.png) MongoDB
 
-Metadata associated with the MongoDB collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-mongodb). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-mongodb).
+Metadata associated with the MongoDB collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-mongodb">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-mongodb">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-mysql/README.md
+++ b/collectd-mysql/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_mysql.png) MySQL
 
-Metadata associated with the MySQL collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-mysql). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/mysql.c).
+Metadata associated with the MySQL collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-mysql">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/mysql.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-nginx-plus/README.md
+++ b/collectd-nginx-plus/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-nginx-plus/img/integrations_nginxplus.png) NGINX Plus
 
-Metadata associated with the NGINX Plus plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-nginx-plus). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-nginx-plus).
+Metadata associated with the NGINX Plus plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-nginx-plus">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-nginx-plus">here</a>.
 
 - [Description](#description)
 - [Installation](#installation)

--- a/collectd-nginx/README.md
+++ b/collectd-nginx/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-nginx/img/integrations_nginx.png) NGINX
 
-Metadata associated with the NGINX collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-nginx). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/nginx.c).
+Metadata associated with the NGINX collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-nginx">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/nginx.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-openstack/README.md
+++ b/collectd-openstack/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integration_openstack.png) OpenStack
 
-Metadata associated with the OpenStack plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-openstack). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-openstack).
+Metadata associated with the OpenStack plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-openstack">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-openstack">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -14,13 +14,13 @@ Metadata associated with the OpenStack plugin for collectd can be found [here](h
 
 This is the SignalFx OpenStack plugin. Follow these instructions to install the OpenStack plugin for collectd.
 
-The [openstack-collectd](https://github.com/signalfx/collectd-openstack) plugin collects metrics from OpenStack components by hitting various endpoints. This plugin covers the following components:
+The <a target="_blank" href="https://github.com/signalfx/collectd-openstack">openstack-collectd</a> plugin collects metrics from OpenStack components by hitting various endpoints. This plugin covers the following components:
 
 * Nova (Compute)
 * Cinder (BlockStorge)
 * Neutron (Network)
 
-Reference for OpenStack [Monitoring](https://wiki.openstack.org/wiki/Operations/Monitoring).
+Reference for OpenStack <a target="_blank" href="https://wiki.openstack.org/wiki/Operations/Monitoring">Monitoring</a>.
 
 #### FEATURES
 
@@ -66,9 +66,9 @@ Identify a host on which the SignalFx agent will run. This integration collects 
 
 ### INSTALLATION
 
-1. Download [collectd-openstack](https://github.com/signalfx/collectd-openstack). Place the `openstack_metrics.py`, `NovaMetrics.py`, `CinderMetrics.py`, and `NeutronMetrics.py` files into the `/usr/share/collectd/collectd-openstack` directory on the deployment host you have identified (see Requirements and Dependencies).
+1. Download <a target="_blank" href="https://github.com/signalfx/collectd-openstack">collectd-openstack</a>. Place the `openstack_metrics.py`, `NovaMetrics.py`, `CinderMetrics.py`, and `NeutronMetrics.py` files into the `/usr/share/collectd/collectd-openstack` directory on the deployment host you have identified (see Requirements and Dependencies).
 
-2. Copy the [sample configuration file](https://github.com/signalfx/integrations/tree/release/collectd-openstack/20-openstack.conf) for this plugin to `/etc/collectd/managed_config` directory.
+2. Copy the <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-openstack/20-openstack.conf">sample configuration file</a> for this plugin to `/etc/collectd/managed_config` directory.
 
 3. Modify the sample configuration file as described in [Configuration](#configuration), below. To avoid duplicate reporting, configure each project only once.
 
@@ -79,7 +79,7 @@ Identify a host on which the SignalFx agent will run. This integration collects 
 
 ### CONFIGURATION
 
-Using the example configuration file [20-openstack.conf](https://github.com/signalfx/integrations/tree/release/collectd-openstack/20-openstack.conf) as a guide, provide configuration values for each project that this integration should monitor.
+Using the example configuration file <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-openstack/20-openstack.conf">20-openstack.conf</a> as a guide, provide configuration values for each project that this integration should monitor.
 
 | Configuration option | Definition | Example Value |
 | ---------------------|------------|---------------|

--- a/collectd-postgresql/README.md
+++ b/collectd-postgresql/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-postgresql/img/integrations_postgresql.png) PostgreSQL
 
-Metadata associated with the PostgreSQL collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-postgresql). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/postgresql.c).
+Metadata associated with the PostgreSQL collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-postgresql">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/postgresql.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-protocols/README.md
+++ b/collectd-protocols/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) Protocols
 
-Metadata associated with the Protocols collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-protocols). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/protocols.c).
+Metadata associated with the Protocols collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-protocols">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/protocols.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -12,7 +12,7 @@ Metadata associated with the Protocols collectd plugin can be found [here](https
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:Protocols):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Protocols">collectd wiki</a>:
 
 The Protocols plugin collects information about the network protocols supported by the system, for example Internet Protocol (IP) and Transmission Control Protocol (TCP). Currently the plugin is only available under Linux and reads its information from the following two files in the /proc file-system:
 
@@ -37,14 +37,14 @@ for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
 
-Configuration for this plugin is kept in the main [collectd.conf](https://github.com/signalfx/integrations/blob/master/collectd/collectd.conf) file.
+Configuration for this plugin is kept in the main <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd/collectd.conf">collectd.conf</a> file.
 
-From [collectd wiki](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_protocols):
+From <a target="_blank" href="https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_protocols">collectd wiki</a>:
 
 | Configuration Option | Type | Definition |
 |----------------------|------|------------|
@@ -73,4 +73,4 @@ For documentation of the metrics and dimensions emitted by this plugin, [click h
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/protocols.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/protocols.c">in the header of the plugin</a>

--- a/collectd-rabbitmq/README.md
+++ b/collectd-rabbitmq/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-rabbitmq/img/integrations_rabbitmq.png) RabbitMQ
 
-Metadata associated with the RabbitMQ collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-rabbitmq). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-rabbitmq).
+Metadata associated with the RabbitMQ collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-rabbitmq">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-rabbitmq">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-redis/README.md
+++ b/collectd-redis/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-redis/img/integrations_redis.png) Redis
 
-Metadata associated with the Redis collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-redis). The relevant code for the plugin can be found [here](https://github.com/signalfx/redis-collectd-plugin).
+Metadata associated with the Redis collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-redis">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/redis-collectd-plugin">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-riak/README.md
+++ b/collectd-riak/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-riak/img/integrations_riak.png) Riak KV
 
-Metadata associated with the Riak KV collectd Configuration can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-riak). The relevant code for the cURL-JSON plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/curl_json.c).
+Metadata associated with the Riak KV collectd Configuration can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-riak">here</a>. The relevant code for the cURL-JSON plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/curl_json.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -12,7 +12,7 @@ Metadata associated with the Riak KV collectd Configuration can be found [here](
 
 ### DESCRIPTION
 
-From [Basho site](http://basho.com/products/riak-kv/):
+From <a target="_blank" href="http://basho.com/products/riak-kv/">Basho site</a>:
 
 Riak KV is a distributed NoSQL database with a key/value design and advanced local and multi-cluster replication that guarantees reads and writes even in the event of hardware failures or network partitions.
 
@@ -43,7 +43,7 @@ This plugin requires:
 
 This plugin is included with [SignalFx's collectd package](https://support.signalfx.com/hc/en-us/articles/208080123).
 
-1. Download SignalFx's [sample configuration file ](https://github.com/signalfx/integrations/tree/master/collectd-riak/10-riak.conf) for this plugin.
+1. Download SignalFx's <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd-riak/10-riak.conf">sample configuration file </a> for this plugin.
 
 2. Modify the sample configuration file as described in [Configuration](#configuration), below.
 
@@ -55,7 +55,7 @@ This plugin is included with [SignalFx's collectd package](https://support.signa
 
 ### CONFIGURATION
 
-Using the example configuration file [10-riak.conf](https://github.com/signalfx/integrations/tree/master/collectd-riak/10-riak.conf) as a guide, provide values for the configuration options listed below that make sense for your environment and allow you to connect to the Riak KV instance to be monitored.
+Using the example configuration file <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd-riak/10-riak.conf">10-riak.conf</a> as a guide, provide values for the configuration options listed below that make sense for your environment and allow you to connect to the Riak KV instance to be monitored.
 
 | Setting	| Value |
 |----------|----------|
@@ -70,13 +70,13 @@ Using the example configuration file [10-riak.conf](https://github.com/signalfx/
 
 #### Note: Monitoring Riak Multi-Datacenter Replication
 
-Replication is part of the Riak KV [enterprise](http://docs.basho.com/riakee/latest/cookbooks/Multi-Data-Center-Replication-Architecture/) package. Unless this feature is enabled, all the metrics available at ../riak-repl/stats will be empty.
+Replication is part of the Riak KV <a target="_blank" href="http://docs.basho.com/riakee/latest/cookbooks/Multi-Data-Center-Replication-Architecture/">enterprise</a> package. Unless this feature is enabled, all the metrics available at ../riak-repl/stats will be empty.
 
 ### USAGE
 
 Below are screen captures of dashboards created for this plugin by SignalFx, illustrating the metrics emitted by this plugin.
 
-For general reference on how to monitor Riak performance, see [Riak Stats and Monitoring](http://docs.basho.com/riak/latest/ops/running/stats-and-monitoring/).
+For general reference on how to monitor Riak performance, see <a target="_blank" href="http://docs.basho.com/riak/latest/ops/running/stats-and-monitoring/">Riak Stats and Monitoring</a>.
 
 **Monitoring Riak Clusters**
 

--- a/collectd-solr/README.md
+++ b/collectd-solr/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_solr.png) Apache Solr
 
-Metadata associated with the solr plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-solr). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-solr).
+Metadata associated with the solr plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-solr">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-solr">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -14,7 +14,7 @@ Metadata associated with the solr plugin for collectd can be found [here](https:
 
 This is the SignalFx solr plugin. Follow these instructions to install the solr plugin for collectd.
 
-The [solr-collectd](https://github.com/signalfx/collectd-solr) plugin collects metrics from solr instances hitting these endpoints: [statistics](https://lucene.apache.org/solr/guide/6_6/performance-statistics-reference.html) (default metrics)  and [metrics](https://lucene.apache.org/solr/guide/6_6/metrics-reporting.html) (optional metrics).
+The <a target="_blank" href="https://github.com/signalfx/collectd-solr">solr-collectd</a> plugin collects metrics from solr instances hitting these endpoints: <a target="_blank" href="https://lucene.apache.org/solr/guide/6_6/performance-statistics-reference.html">statistics</a> (default metrics)  and <a target="_blank" href="https://lucene.apache.org/solr/guide/6_6/metrics-reporting.html">metrics</a> (optional metrics).
 
 #### FEATURES
 
@@ -52,9 +52,9 @@ The [solr-collectd](https://github.com/signalfx/collectd-solr) plugin collects m
 
 ### INSTALLATION
 
-1. Download [collectd-solr](https://github.com/signalfx/collectd-solr). Place the `solr_collectd.py` file in `/usr/share/collectd/collectd-solr`
+1. Download <a target="_blank" href="https://github.com/signalfx/collectd-solr">collectd-solr</a>. Place the `solr_collectd.py` file in `/usr/share/collectd/collectd-solr`
 
-2. Modify the [sample configuration file](https://github.com/signalfx/integrations/tree/release/collectd-solr/20-solr.conf) for this plugin to `/etc/collectd/managed_config`
+2. Modify the <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-solr/20-solr.conf">sample configuration file</a> for this plugin to `/etc/collectd/managed_config`
 
 3. Modify the sample configuration file as described in [Configuration](#configuration), below
 
@@ -65,7 +65,7 @@ The [solr-collectd](https://github.com/signalfx/collectd-solr) plugin collects m
 
 ### CONFIGURATION
 
-Using the example configuration file [20-solr.conf](https://github.com/signalfx/integrations/tree/release/collectd-solr/20-solr.conf) as a guide, provide values for the configuration options listed below that make sense for your environment and allow you to connect to the solr nodes
+Using the example configuration file <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-solr/20-solr.conf">20-solr.conf</a> as a guide, provide values for the configuration options listed below that make sense for your environment and allow you to connect to the solr nodes
 
 | configuration option | definition | example value |
 | ---------------------|------------|---------------|

--- a/collectd-spark/README.md
+++ b/collectd-spark/README.md
@@ -2,7 +2,7 @@
 
 **Plugin currently supports cluster modes Standalone and Mesos**
 
-Metadata associated with the spark plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-spark). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-spark).
+Metadata associated with the spark plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-spark">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-spark">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-statsd/README.md
+++ b/collectd-statsd/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-statsd/img/integrations_statsd.png) StatsD
 
-Metadata associated with the StatsD collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-statsd). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/statsd.c).
+Metadata associated with the StatsD collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-statsd">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/statsd.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/collectd-tail-syslog/README.md
+++ b/collectd-tail-syslog/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) Tail collectd Plugin
 
-Metadata associated with the Tail collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-tail-syslog). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/tail.c).
+Metadata associated with the Tail collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-tail-syslog">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/tail.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -10,9 +10,9 @@ Metadata associated with the Tail collectd plugin can be found [here](https://gi
 
 ### DESCRIPTION
 
-From the [collectd wiki](https://collectd.org/wiki/index.php/Plugin:Tail):
+From the <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Tail">collectd wiki</a>:
 
-The Tail plugin can be used to “tail” log files, i. e. follow them as tail -F does. Each line is given to one or more “matches” which test if the line is relevant for any statistics using a [POSIX extended regular expression](http://en.wikipedia.org/wiki/Regular_expression). So you could, for example, count the number of failed login attempts via SSH by using the following regular expression with the `/var/log/auth.log` logfile:
+The Tail plugin can be used to “tail” log files, i. e. follow them as tail -F does. Each line is given to one or more “matches” which test if the line is relevant for any statistics using a <a target="_blank" href="http://en.wikipedia.org/wiki/Regular_expression">POSIX extended regular expression</a>. So you could, for example, count the number of failed login attempts via SSH by using the following regular expression with the `/var/log/auth.log` logfile:
 
 ```
 \<sshd[^:]*: Invalid user [^ ]+ from\>
@@ -61,19 +61,19 @@ This plugin requires:
 
 ### INSTALLATION
 
-This plugin is automatically bundled with the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd), but it is not enabled by default.
+This plugin is automatically bundled with the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>, but it is not enabled by default.
 
 
 ### CONFIGURATION
 
-Please see the [collectd wiki](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_tail) for information on how to configure this plugin.
+Please see the <a target="_blank" href="https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_tail">collectd wiki</a> for information on how to configure this plugin.
 
-Additionally, some sample configurations can be found [here](https://collectd.org/wiki/index.php/Plugin:Tail/Config).
+Additionally, some sample configurations can be found <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Tail/Config">here</a>.
 
 ### CAVEATS
 
-This plugin was created by the collectd community to satisfy “modest” log tailing use cases that typically involve monitoring at most a small handful of logs for matches with up to a couple dozen regular expressions in each log. (See [here](https://collectd.org/wiki/index.php/Plugin:Tail/Config) for several examples). Its creators haven’t specifically noted any caveats related to its usage or performance, possibly due to the difficulty in doing so given the number of variables involved. It is reasonable to expect that at some point this plugin will have difficulty scaling under typical regex configuration once the number of logs it is tasked with monitoring increases into double digits, especially if the logs are very active.
+This plugin was created by the collectd community to satisfy “modest” log tailing use cases that typically involve monitoring at most a small handful of logs for matches with up to a couple dozen regular expressions in each log. (See <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Tail/Config">here</a> for several examples). Its creators haven’t specifically noted any caveats related to its usage or performance, possibly due to the difficulty in doing so given the number of variables involved. It is reasonable to expect that at some point this plugin will have difficulty scaling under typical regex configuration once the number of logs it is tasked with monitoring increases into double digits, especially if the logs are very active.
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/tail.c).
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/tail.c">in the header of the plugin</a>.

--- a/collectd-uptime/README.md
+++ b/collectd-uptime/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) Uptime collectd Plugin
 
-Metadata associated with the Tail collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-uptime). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/uptime.c).
+Metadata associated with the Tail collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-uptime">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/uptime.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -12,7 +12,7 @@ Metadata associated with the Tail collectd plugin can be found [here](https://gi
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:Uptime)
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:Uptime">collectd wiki</a>
 
 > The Uptime plugin keeps track of the system uptime, providing informations such as the average running time or the maximum reached uptime over a certain period of time. It can be useful especially on Linux based routers/firewalls.
 
@@ -32,7 +32,7 @@ for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
@@ -49,4 +49,4 @@ For documentation of the metrics and dimensions emitted by this plugin, [click h
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/uptime.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/uptime.c">in the header of the plugin</a>

--- a/collectd-varnish/README.md
+++ b/collectd-varnish/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-varnish/img/integrations_varnish.png) Varnish
 
-Metadata associated with the Varnish collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-varnish). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/varnish.c).
+Metadata associated with the Varnish collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-varnish">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/varnish.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -52,7 +52,7 @@ Varnish Cache is a web application accelerator also known as a caching HTTP reve
 Starting with collectd 5.6.1-sfx0, the varnish plugin provided within the SignalFx Package only supports varnish 4.
 Follow these steps to add varnish 3 plugin support:
 
-1. Copy the [varnish3.so](https://dl.signalfx.com/debs/collectd-varnish/varnish3.so) file to the collectd library directory `/usr/lib/collectd/`.
+1. Copy the <a target="_blank" href="https://dl.signalfx.com/debs/collectd-varnish/varnish3.so">varnish3.so</a> file to the collectd library directory `/usr/lib/collectd/`.
 
 2. Update the configuration file `10-varnish.conf` in your `/etc/collectd/managed_config` directory to show `varnish3` instead of `varnish` as the name used by the LoadPlugin.
 

--- a/collectd-vmem/README.md
+++ b/collectd-vmem/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) vmem
 
-Metadata associated with the vmem collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-vmem). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/vmem.c).
+Metadata associated with the vmem collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-vmem">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/vmem.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -11,7 +11,7 @@ Metadata associated with the vmem collectd plugin can be found [here](https://gi
 
 ### DESCRIPTION
 
-From [collectd wiki](https://collectd.org/wiki/index.php/Plugin:vmem):
+From <a target="_blank" href="https://collectd.org/wiki/index.php/Plugin:vmem">collectd wiki</a>:
 
 > The vmem plugin collects information about the virtual memory subsystem of the kernel. Per default, information such as page-faults, page-in and page-out to and from memory and swap, and the total number of pages are collected. When verbose statistics are enabled, all page actions (allocations, refills, steals, …) are collected per zone (DMA, DMA32, …).
 
@@ -31,14 +31,14 @@ for more information.  The configuration documentation below may be helpful as
 well, but consult the Smart Agent repo's docs for the exact schema.**
 
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
 
-Configuration for this plugin is kept in the main [collectd.conf](https://github.com/signalfx/integrations/blob/master/collectd/collectd.conf) file.
+Configuration for this plugin is kept in the main <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/collectd/collectd.conf">collectd.conf</a> file.
 
-From the [collectd wiki](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_vmem):
+From the <a target="_blank" href="https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_vmem">collectd wiki</a>:
 
 > The vmem plugin collects information about the usage of virtual memory. Since the statistics provided by the Linux kernel are very detailed, they are collected very detailed. However, to get all the details, you have to switch them on manually. Most people just want an overview over, such as the number of pages read from swap space.
 
@@ -52,4 +52,4 @@ For documentation of the metrics and dimensions emitted by this plugin, [click h
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/vmem.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/vmem.c">in the header of the plugin</a>

--- a/collectd-vmstat/README.md
+++ b/collectd-vmstat/README.md
@@ -1,6 +1,6 @@
 # VMStat
 
-Metadata associated with the VMStat plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-vmstat).  The relevant code for the plugin can be found [here](https://github.com/signalfx/vmstat-collectd).
+Metadata associated with the VMStat plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-vmstat">here</a>.  The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/vmstat-collectd">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -30,14 +30,14 @@ At this time there are no built in dashboards.  You may find metrics reported by
 
 ### INSTALLATION
 1.  Ensure that vmstat is installed on the host.
-2.  Download the [vmstat-collectd](https://github.com/signalfx/vmstat-collectd) Python module
+2.  Download the <a target="_blank" href="https://github.com/signalfx/vmstat-collectd">vmstat-collectd</a> Python module
 3.  Place the contents of the repo in /usr/share/collectd/vmstat-collectd
 4.  Download SignalFx’s [sample configuration file](./10-vmstat.conf) for this plugin to `/etc/collectd/managed_config`.
 5.  Modify the configuration file to provide values that make sense for your environment, as described in [Configuration](#configuration) below.
 6.  Restart collectd.
 
 ### CONFIGURATION
-Using the example configuration file [10-vmstat.conf](https://github.com/signalfx/integrations/tree/master/collectd-vmstat/10-vmstat.conf) as a guide, provide values for the configuration options listed below that make sense for your environment.
+Using the example configuration file <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd-vmstat/10-vmstat.conf">10-vmstat.conf</a> as a guide, provide values for the configuration options listed below that make sense for your environment.
 
 | configuration option | definition | default value |
 | ---------------------|------------|---------------|

--- a/collectd-write_http/README.md
+++ b/collectd-write_http/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integrations_collectd.png) Write-HTTP
 
-Metadata associated with the Write-HTTP collectd plugin can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-write_http). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd/blob/master/src/write_http.c).
+Metadata associated with the Write-HTTP collectd plugin can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-write_http">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/write_http.c">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -10,7 +10,7 @@ Metadata associated with the Write-HTTP collectd plugin can be found [here](http
 
 ### DESCRIPTION
 
-The Write HTTP plugin sends the values collected by collectd to a web-server using HTTP POST requests. The data is formatted as PUTVAL commands, see plain text protocol. The [SignalFx collectd agent](https://github.com/signalfx/collectd) version of this plugin has been extended with **Buffer Flushing** to ensure that metrics always arrive in a timely manner, we’ve added a timer so that it transmits data to SignalFx either when the data buffer is full or when a time limit is reached, whichever happens first. This capability is particularly useful if you are only collecting small quantities of time-sensitive metrics.
+The Write HTTP plugin sends the values collected by collectd to a web-server using HTTP POST requests. The data is formatted as PUTVAL commands, see plain text protocol. The <a target="_blank" href="https://github.com/signalfx/collectd">SignalFx collectd agent</a> version of this plugin has been extended with **Buffer Flushing** to ensure that metrics always arrive in a timely manner, we’ve added a timer so that it transmits data to SignalFx either when the data buffer is full or when a time limit is reached, whichever happens first. This capability is particularly useful if you are only collecting small quantities of time-sensitive metrics.
 
 ### REQUIREMENTS AND DEPENDENCIES
 
@@ -22,12 +22,12 @@ This plugin requires:
 
 ### INSTALLATION
 
-Installation and initial configuration options are available as part of the [SignalFx collectd agent](https://github.com/signalfx/integrations/tree/master/collectd).
+Installation and initial configuration options are available as part of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/collectd">SignalFx collectd agent</a>.
 
 
 ### CONFIGURATION
 
-From [collectd wiki](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_write_http):
+From <a target="_blank" href="https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_write_http">collectd wiki</a>:
 
 >This output plugin submits values to an HTTP server using POST requests and encoding metrics with JSON or using the PUTVAL command described in collectd-unixsock(5).
 
@@ -70,4 +70,4 @@ Synopsis:
 
 ### LICENSE
 
-License for this plugin can be found [in the header of the plugin](https://github.com/signalfx/collectd/blob/master/src/write_http.c)
+License for this plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd/blob/master/src/write_http.c">in the header of the plugin</a>

--- a/collectd-zookeeper/README.md
+++ b/collectd-zookeeper/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd-zookeeper/img/integrations_zookeeper.png) Zookeeper
 
-Metadata associated with SignalFx's integration with Zookeeper can be found [here](https://github.com/signalfx/integrations/tree/release/collectd-zookeeper). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-zookeeper).
+Metadata associated with SignalFx's integration with Zookeeper can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd-zookeeper">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-zookeeper">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -38,7 +38,7 @@ This plugin requires:
 | Zookeeper         | 3.4.0+   |
 
 #### Note:
- - Requires ZooKeeper 3.4.0 or greater in order to use the `mntr` [four letter word command](http://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html#sc_zkCommands).
+ - Requires ZooKeeper 3.4.0 or greater in order to use the `mntr` <a target="_blank" href="http://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html#sc_zkCommands">four letter word command</a>.
  - If support for earlier versions is needed, add `srvr` command, available in since 3.3.0, or `stat` (fetches extra uneeded data but available pre-3.3).
 
 

--- a/collectd/README.md
+++ b/collectd/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/collectd/img/integration_signalfx.png) SignalFx collectd agent
 
-Metadata associated with the SignalFx collectd agent can be found [here](https://github.com/signalfx/integrations/tree/release/collectd). The code repository for this project can be found [here](https://github.com/signalfx/collectd/).
+Metadata associated with the SignalFx collectd agent can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/collectd">here</a>. The code repository for this project can be found <a target="_blank" href="https://github.com/signalfx/collectd/">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/google-appengine/README.md
+++ b/google-appengine/README.md
@@ -130,7 +130,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google App Engine, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-appengine
+For more information about the metrics emitted by Google App Engine, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-appengine">https://cloud.google.com/monitoring/api/metrics#gcp-appengine</a>
 
 ### LICENSE
 

--- a/google-bigquery/README.md
+++ b/google-bigquery/README.md
@@ -53,7 +53,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google BigQuery, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-bigquery
+For more information about the metrics emitted by Google BigQuery, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-bigquery">https://cloud.google.com/monitoring/api/metrics#gcp-bigquery</a>
 
 ### LICENSE
 

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -162,7 +162,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google Cloud Bigtable, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-bigtable
+For more information about the metrics emitted by Google Cloud Bigtable, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-bigtable">https://cloud.google.com/monitoring/api/metrics#gcp-bigtable</a>
 
 ### LICENSE
 

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -47,7 +47,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google Cloud Datastore, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-datastore
+For more information about the metrics emitted by Google Cloud Datastore, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-datastore">https://cloud.google.com/monitoring/api/metrics#gcp-datastore</a>
 
 ### LICENSE
 

--- a/google-cloud-functions/README.md
+++ b/google-cloud-functions/README.md
@@ -69,7 +69,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google Cloud Functions, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-cloudfunctions
+For more information about the metrics emitted by Google Cloud Functions, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-cloudfunctions">https://cloud.google.com/monitoring/api/metrics#gcp-cloudfunctions</a>
 
 ### LICENSE
 

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -110,7 +110,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google Cloud Pub/Sub, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-pubsub
+For more information about the metrics emitted by Google Cloud Pub/Sub, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-pubsub">https://cloud.google.com/monitoring/api/metrics#gcp-pubsub</a>
 
 ### LICENSE
 

--- a/google-cloud-router/README.md
+++ b/google-cloud-router/README.md
@@ -89,7 +89,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google Cloud Router, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-router
+For more information about the metrics emitted by Google Cloud Router, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-router">https://cloud.google.com/monitoring/api/metrics#gcp-router</a>
 
 ### LICENSE
 

--- a/google-cloud-spanner/README.md
+++ b/google-cloud-spanner/README.md
@@ -80,7 +80,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google Cloud Spanner, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-spanner
+For more information about the metrics emitted by Google Cloud Spanner, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-spanner">https://cloud.google.com/monitoring/api/metrics#gcp-spanner</a>
 
 ### LICENSE
 

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -68,7 +68,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google Cloud Storage, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-storage
+For more information about the metrics emitted by Google Cloud Storage, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-storage">https://cloud.google.com/monitoring/api/metrics#gcp-storage</a>
 
 ### LICENSE
 

--- a/google-compute-engine/README.md
+++ b/google-compute-engine/README.md
@@ -120,7 +120,7 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 ### METRICS
 
-For more information about the metrics emitted by Google Compute Engine, visit the service's metric page at https://cloud.google.com/monitoring/api/metrics#gcp-compute
+For more information about the metrics emitted by Google Compute Engine, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-compute">https://cloud.google.com/monitoring/api/metrics#gcp-compute</a>
 
 ### LICENSE
 

--- a/google-container-engine/README.md
+++ b/google-container-engine/README.md
@@ -31,7 +31,7 @@ Use SignalFx to monitor Google Container Engine via [Google Cloud Platform](http
 
 To access this integration, [connect to Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-**Note**: Stackdriver Monitoring may not be enabled by default for your cluster. To enable it so that these metrics can be retrieved by SignalFx please see [this page](https://cloud.google.com/kubernetes-engine/docs/how-to/monitoring).
+**Note**: Stackdriver Monitoring may not be enabled by default for your cluster. To enable it so that these metrics can be retrieved by SignalFx please see <a target="_blank" href="https://cloud.google.com/kubernetes-engine/docs/how-to/monitoring">this page</a>.
 
 ### USAGE
 

--- a/heka-filter-signalfx/README.md
+++ b/heka-filter-signalfx/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/heka-filter-signalfx/img/integrations_heka.png) Heka Filter for SignalFx
 
-Metadata associated with the Heka filter integration can be found [here](https://github.com/signalfx/integrations/tree/release/heka-filter-signalfx). The relevant code for the integration can be found [here](https://github.com/Clever/heka-clever-plugins/blob/master/lua/filters/signalfxbatch.lua).
+Metadata associated with the Heka filter integration can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/heka-filter-signalfx">here</a>. The relevant code for the integration can be found <a target="_blank" href="https://github.com/Clever/heka-clever-plugins/blob/master/lua/filters/signalfxbatch.lua">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -10,7 +10,7 @@ Metadata associated with the Heka filter integration can be found [here](https:/
 
 ### DESCRIPTION
 
-This integration provides support for pushing Heka metrics into SignalFx. [Heka](http://hekad.readthedocs.org/en/v0.10.0/) is an open source stream processing software system developed by Mozilla. This filter for was built by Clever, a SignalFx customer. The integration extracts data from Fields in messages. Generates JSON suitable for send to datapoint SignalFx API. Batches multiple messages into one string, which can be passed to an `HttpOutput` using a `PayloadEncoder`. Currently, only supports writing data points, NOT events.
+This integration provides support for pushing Heka metrics into SignalFx. <a target="_blank" href="http://hekad.readthedocs.org/en/v0.10.0/">Heka</a> is an open source stream processing software system developed by Mozilla. This filter for was built by Clever, a SignalFx customer. The integration extracts data from Fields in messages. Generates JSON suitable for send to datapoint SignalFx API. Batches multiple messages into one string, which can be passed to an `HttpOutput` using a `PayloadEncoder`. Currently, only supports writing data points, NOT events.
 
 Heka is a “Swiss Army Knife” type tool for data processing, useful for a wide variety of different tasks, such as:
 
@@ -31,11 +31,11 @@ This filter requires:
 
 ### INSTALLATION
 
-Heka installation instructions are available in the [Heka documentation](http://hekad.readthedocs.org/en/v0.10.0/installing.html)
+Heka installation instructions are available in the <a target="_blank" href="http://hekad.readthedocs.org/en/v0.10.0/installing.html">Heka documentation</a>
 
 ### CONFIGURATION
 
-Full Heka configuration setting are available in the [Heka docs](http://hekad.readthedocs.org/en/v0.10.0/config/index.html)
+Full Heka configuration setting are available in the <a target="_blank" href="http://hekad.readthedocs.org/en/v0.10.0/config/index.html">Heka docs</a>
 
 Configuration for the SignalFx filter:
 
@@ -82,7 +82,7 @@ Configuration for the SignalFx filter:
 
 ### METRICS
 
-Documentation of the metrics and dimensions emitted by this integration, are available in the [Heka docs](https://hekad.readthedocs.org/en/v0.10.0/config/outputs/index.html#common-output-parameters).
+Documentation of the metrics and dimensions emitted by this integration, are available in the <a target="_blank" href="https://hekad.readthedocs.org/en/v0.10.0/config/outputs/index.html#common-output-parameters">Heka docs</a>.
 
 ### LICENSE
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/kubernetes/img/integrations_kubernetes.png) Kubernetes
 
-Metadata associated with the Kubernetes integration can be found [here](https://github.com/signalfx/integrations/tree/release/kubernetes). The relevant documentation for the project can be found [here](https://docs.signalfx.com/en/latest/integrations/kubernetes-quickstart.html).
+Metadata associated with the Kubernetes integration can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/kubernetes">here</a>. The relevant documentation for the project can be found <a target="_blank" href="https://docs.signalfx.com/en/latest/integrations/kubernetes-quickstart.html">here</a>.
 
 - [Description](#description)
 - [Metrics](#metrics)

--- a/lib-go/README.md
+++ b/lib-go/README.md
@@ -1,12 +1,12 @@
 # ![](https://github.com/signalfx/integrations/blob/master/lib-go/img/integrations_golang.png) Go library for SignalFx
 
-Metadata associated with the Go library for SignalFx can be found [here](https://github.com/signalfx/integrations/tree/release/lib-go). The relevant code for the library can be found [here](https://github.com/signalfx/golib/tree/master/sfxclient).
+Metadata associated with the Go library for SignalFx can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/lib-go">here</a>. The relevant code for the library can be found <a target="_blank" href="https://github.com/signalfx/golib/tree/master/sfxclient">here</a>.
 
 ```
     import "github.com/signalfx/golib/sfxclient"
 ```
 
-Package [signalfx](https://github.com/signalfx/golib/tree/master/sfxclient) creates convenient Go functions and wrappers to send metrics to SignalFx.
+Package <a target="_blank" href="https://github.com/signalfx/golib/tree/master/sfxclient">signalfx</a> creates convenient Go functions and wrappers to send metrics to SignalFx.
 
 The core of the library is HTTPDatapointSink which allows users to send metrics to SignalFx ad-hoc. A Scheduler is built on top of this to facility easy management of metrics for multiple SignalFx reporters at once in more complex libraries.
 

--- a/lib-java/README.md
+++ b/lib-java/README.md
@@ -13,7 +13,7 @@
 
 ### DESCRIPTION
 
-This [repository](https://github.com/signalfx/integrations/tree/release/lib-java) contains libraries for instrumenting Java applications and reporting metrics to SignalFx, using Codahale Metrics.
+This <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/lib-java">repository</a> contains libraries for instrumenting Java applications and reporting metrics to SignalFx, using Codahale Metrics.
 
 You can also use the module `signalfx-java` to send metrics directly to SignalFx using protocol buffers, without using Codahale or Yammer metrics.
 
@@ -22,7 +22,7 @@ You can also use the module `signalfx-java` to send metrics directly to SignalFx
 
 #### Codahale, Yammer and Dropwizard Metrics version
 
-We recommend sending metrics with Java using Codahale Metrics version 3.0+. You can also use Yammer Metrics 2.0.x (an earlier version of Codahale Metrics). More information on the Codahale Metrics library can be found on the [Codahale Metrics website](https://dropwizard.github.io/metrics/).
+We recommend sending metrics with Java using Codahale Metrics version 3.0+. You can also use Yammer Metrics 2.0.x (an earlier version of Codahale Metrics). More information on the Codahale Metrics library can be found on the <a target="_blank" href="https://dropwizard.github.io/metrics/">Codahale Metrics website</a>.
 
 #### Supported languages
 
@@ -32,7 +32,7 @@ Java 6+ with `signalfx-metrics`.
 #### API access token
 
 
-To use this library, you need a SignalFx API access token. [Click here for more information on retrieving an API token](https://developers.signalfx.com/docs/authentication).
+To use this library, you need a SignalFx API access token. <a target="_blank" href="https://developers.signalfx.com/docs/authentication">Click here for more information on retrieving an API token</a>.
 
 
 ### INSTALLATION

--- a/lib-node/README.md
+++ b/lib-node/README.md
@@ -22,7 +22,7 @@
 
 #### API access token
 
-To use this library, you need a SignalFx API access token. [Click here for more information on retrieving your API token](https://developers.signalfx.com/docs/authentication).
+To use this library, you need a SignalFx API access token. <a target="_blank" href="https://developers.signalfx.com/docs/authentication">Click here for more information on retrieving your API token</a>.
 
 
 ### INSTALLATION

--- a/lib-python/README.md
+++ b/lib-python/README.md
@@ -29,7 +29,7 @@ Python 2.7.9 or higher is recommended. If you are not making API calls to intera
 #### API access token
 
 To use this library, you need a SignalFx API access
-token. [Click here for more information on retrieving your API token](https://developers.signalfx.com/docs/authentication).
+token. <a target="_blank" href="https://developers.signalfx.com/docs/authentication">Click here for more information on retrieving your API token</a>.
 
 ### INSTALLATION
 
@@ -114,7 +114,7 @@ sfx.send(
 sfx.stop()
 ```
 
-See [examples/generic_usecase.py](examples/generic_usecase.py) for a
+See <a target="_blank" href="examples/generic_usecase.py">examples/generic_usecase.py</a> for a
 complete code sample showing how to send data to SignalFx.
 
 #### Sending events
@@ -152,7 +152,7 @@ sfx.update_tag('some_tag_name',
 
 #### AWS integration
 
-Optionally, the client may be configured to append additional dimensions to all metrics and events sent to SignalFx. One use case for this is to append the [AWS unique ID](https://signalfx-product-docs.readthedocs-hosted.com/en/latest/integrations/aws-info.html#uniquely-identifying-aws-instances) of the current host as an extra dimension. For example:
+Optionally, the client may be configured to append additional dimensions to all metrics and events sent to SignalFx. One use case for this is to append the <a target="_blank" href="https://signalfx-product-docs.readthedocs-hosted.com/en/latest/integrations/aws-info.html#uniquely-identifying-aws-instances">AWS unique ID</a> of the current host as an extra dimension. For example:
 
 ```python
 import signalfx
@@ -174,7 +174,7 @@ sfx.stop()
 
 #### PyFormance reporter
 
-`pyformance` is a [Python library](https://github.com/omergertel/pyformance) that provides [CodaHale](http://metrics.codahale.com/)-style metrics in a very Pythonic way. We offer a reporter that can report the `pyformance` metric registry data directly to SignalFx.
+`pyformance` is a <a target="_blank" href="https://github.com/omergertel/pyformance">Python library</a> that provides <a target="_blank" href="http://metrics.codahale.com/">CodaHale</a>-style metrics in a very Pythonic way. We offer a reporter that can report the `pyformance` metric registry data directly to SignalFx.
 
 ```python
 from pyformance import count_calls, gauge

--- a/lib-ruby/README.md
+++ b/lib-ruby/README.md
@@ -28,7 +28,7 @@ This library supports Ruby 2.x.
 #### API access token
 
 To use this library, you need a SignalFx API access
-token. [Click here for more information on retrieving your API token](https://developers.signalfx.com/docs/authentication-overview).
+token. <a target="_blank" href="https://developers.signalfx.com/docs/authentication-overview">Click here for more information on retrieving your API token</a>.
 
 
 ### INSTALLATION
@@ -163,4 +163,4 @@ See `examples/generic_usecase.rb` for a complete code example for Reporting data
 
 ### LICENSE
 
-Apache Software License v2 © [SignalFx](https://signalfx.com)
+Apache Software License v2 © <a target="_blank" href="https://signalfx.com">SignalFx</a>

--- a/logstash-ciscoxr/README.md
+++ b/logstash-ciscoxr/README.md
@@ -9,7 +9,7 @@
 
 ### DESCRIPTION
 
-This integration for Cisco IOS XR telemetry metrics was build by the Cisco IOS XR team as part of the [bigmuddy-network-telemetry-stacks](https://github.com/cisco/bigmuddy-network-telemetry-stacks). The integration utilizes [logstash](https://www.elastic.co/products/logstash) for initial metric collection and then adds a plugin to export the metrics directly to SignalFx in the appropriate format.
+This integration for Cisco IOS XR telemetry metrics was build by the Cisco IOS XR team as part of the <a target="_blank" href="https://github.com/cisco/bigmuddy-network-telemetry-stacks">bigmuddy-network-telemetry-stacks</a>. The integration utilizes <a target="_blank" href="https://www.elastic.co/products/logstash">logstash</a> for initial metric collection and then adds a plugin to export the metrics directly to SignalFx in the appropriate format.
 
 ### REQUIREMENTS AND DEPENDENCIES
 
@@ -22,9 +22,9 @@ This integration requires:
 
 ### INSTALLATION
 
-Installation directions are provided by [Cisco](https://github.com/cisco/bigmuddy-network-telemetry-stacks):
+Installation directions are provided by <a target="_blank" href="https://github.com/cisco/bigmuddy-network-telemetry-stacks">Cisco</a>:
 
->You will need a working [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [docker](https://docs.docker.com/installation/) setup; look for "Docker tips" below if you need help with this. If host is behind an HTTP proxy, refer to the pertinent section below.
+>You will need a working <a target="_blank" href="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git">git</a> and <a target="_blank" href="https://docs.docker.com/installation/">docker</a> setup; look for "Docker tips" below if you need help with this. If host is behind an HTTP proxy, refer to the pertinent section below.
 
 >Clone the repository, pick the stack you would like to run, and follow the steps below. I use `stack_elk` as an example, but the same applies for `stack_prometheus`, `stack_signalfx` or `stack_kafka`:
 
@@ -55,14 +55,14 @@ sudo ./stack_run
 sudo ./stack_stop
 ```
 
->The stack can be started and stopped over and over (no intervening `stack_build` required). Configuration and data is preserved across stop/run cycles in the [host mounted volumes](https://docs.docker.com/userguide/dockervolumes/). A host mounted volume is a  per-stack-component directory which is mapped into the container.
+>The stack can be started and stopped over and over (no intervening `stack_build` required). Configuration and data is preserved across stop/run cycles in the <a target="_blank" href="https://docs.docker.com/userguide/dockervolumes/">host mounted volumes</a>. A host mounted volume is a  per-stack-component directory which is mapped into the container.
 
 >If the stack is (re)built, configuration files which are copied from the repository are regenerated and any changes to those files in the host mounted volume will be overwritten. Any other data is preserved unless the host mounted volumes are deleted explicitly. If you wish to purge all data and configuration to start from scratch, simply delete the host mounted volumes, and rerun `stack_build`.
 
 
 ### CONFIGURATION
 
-Configuration directions are provided by [Cisco](https://github.com/cisco/bigmuddy-network-telemetry-stacks):
+Configuration directions are provided by <a target="_blank" href="https://github.com/cisco/bigmuddy-network-telemetry-stacks">Cisco</a>:
 
 >In order to use `stack_signalfx`, registration is required at https://signalfx.com/. Once registered, an organisation API Token can be retrieved from the profile page. This token should be setup in the `stack_signalfx/src/environment` as shown here (note the token is not made up in the example):
 

--- a/metricproxy/README.md
+++ b/metricproxy/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/metricproxy/img/integrations_metricproxy.png) SignalFx metric proxy
 
-Information associated with the SignalFx metric proxy can be found [here](https://github.com/signalfx/integrations/tree/release/metricproxy). The relevant code for the project can be found [here](https://github.com/signalfx/metricproxy).
+Information associated with the SignalFx metric proxy can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/metricproxy">here</a>. The relevant code for the project can be found <a target="_blank" href="https://github.com/signalfx/metricproxy">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -46,7 +46,7 @@ The size of the machine that hosts the proxy depends on the amount of data that 
 
 #### Note: Deploying using Docker
 
- The SignalFx metric proxy is also packaged as a Docker image that has been built and deployed to [quay.io](https://quay.io/repository/signalfx/metricproxy). This image does not include configuration. To use this image, ensure that you have a `sfdbproxy.conf` file cross-mounted to `/var/config/sfproxy/sfdbproxy.conf` for the container to use. As an example, if you have the configuration file setup on the host at the location `/tmp/proxy/sfdbproxy.conf` then the docker command would be `docker run -ti -v /tmp/proxy:/var/config/sfproxy quay.io/signalfx/metricproxy`
+ The SignalFx metric proxy is also packaged as a Docker image that has been built and deployed to <a target="_blank" href="https://quay.io/repository/signalfx/metricproxy">quay.io</a>. This image does not include configuration. To use this image, ensure that you have a `sfdbproxy.conf` file cross-mounted to `/var/config/sfproxy/sfdbproxy.conf` for the container to use. As an example, if you have the configuration file setup on the host at the location `/tmp/proxy/sfdbproxy.conf` then the docker command would be `docker run -ti -v /tmp/proxy:/var/config/sfproxy quay.io/signalfx/metricproxy`
 
 ### CONFIGURATION
 

--- a/pops/README.md
+++ b/pops/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/pops/img/integrations_pops.png) SignalFx Point of Presence Service (POPS)
 
-Information associated with the SignalFx POPS can be found [here](https://github.com/signalfx/integrations/tree/release/pops). The relevant code for the project can be found [here](https://github.com/signalfx/pops).
+Information associated with the SignalFx POPS can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/pops">here</a>. The relevant code for the project can be found <a target="_blank" href="https://github.com/signalfx/pops">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/signalfx-agent/README.md
+++ b/signalfx-agent/README.md
@@ -4,7 +4,7 @@
 
 ### DESCRIPTION
 
-See [the Github repo](https://github.com/signalfx/signalfx-agent) for the
+See <a target="_blank" href="https://github.com/signalfx/signalfx-agent">the Github repo</a> for the
 source code along with more extensive documentation.
 ## SignalFx Smart Agent 
 
@@ -31,7 +31,7 @@ services and automatically configure the Smart Agent to send metrics for those
 services.
 
 For a list of supported observers and their configurations,
-see [Observer Config](https://github.com/signalfx/signalfx-agent/tree/master/docs/observer-config.md).
+see <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/observer-config.md">Observer Config</a>.
 
 #### Monitors
 
@@ -42,12 +42,12 @@ configuration. A separate monitor instance is created for each discovered
 instance of applications that match a discovery rule. See [Auto
 Discovery](https://github.com/signalfx/signalfx-agent/tree/master/docs/auto-discovery.md) for more information.
 
-Many of the monitors are built around [collectd](https://collectd.org), an open
+Many of the monitors are built around <a target="_blank" href="https://collectd.org">collectd</a>, an open
 source third-party monitor, and use it to collect metrics. Some other monitors
 do not use collectd. However, either type is configured in the same way.
 
 For a list of supported monitors and their configurations, 
-see [Monitor Config](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitor-config.md).
+see <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/monitor-config.md">Monitor Config</a>.
 
 The Smart Agent is primarily intended to monitor services/applications running on the
 same host as the Smart Agent.  This is in keeping with the collectd model.  The main
@@ -60,7 +60,7 @@ machine during metric analysis.
 #### Writer
 The writer collects metrics emitted by the configured monitors and sends them
 to SignalFx on a regular basis.  There are a few things that can be
-[configured](https://github.com/signalfx/signalfx-agent/tree/master/docs/config-schema.md#writer) in the writer, but this is generally
+<a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/config-schema.md#writer">configured</a> in the writer, but this is generally
 only necessary if you have a very large number of metrics flowing through a
 single agent.
 
@@ -72,7 +72,7 @@ agent, including a Java JRE runtime and a Python runtime, so there are no
 additional dependencies required.  This means that the Smart Agent should work on any
 relatively modern Linux distribution (kernel version 2.6+).  To get started
 deploying the Smart Agent directly on a host, see the
-[Smart Agent Quickstart](https://github.com/signalfx/signalfx-agent/tree/master/docs/smart-agent-quickstart.md) guide.
+<a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/smart-agent-quickstart.md">Smart Agent Quickstart</a> guide.
 
 #### Deployment
 We support the following deployment/configuration management tools to automate the
@@ -112,10 +112,10 @@ We also offer a Salt Formula to install and configure the Smart Agent.  See [the
 formula source](https://github.com/signalfx/signalfx-agent/tree/master/deployments/salt).
 
 ##### Docker Image
-See [Docker Deployment](https://github.com/signalfx/signalfx-agent/tree/master/deployments/docker) for more information.
+See <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/deployments/docker">Docker Deployment</a> for more information.
 
 ##### Kubernetes
-See our [Kubernetes setup instructions](https://github.com/signalfx/signalfx-agent/tree/master/docs/kubernetes-setup.md) and the
+See our <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/kubernetes-setup.md">Kubernetes setup instructions</a> and the
 documentation on [Monitoring
 Kubernetes](https://docs.signalfx.com/en/latest/integrations/kubernetes-quickstart.html)
 for more information.
@@ -175,7 +175,7 @@ options that you will especially want to consider:
 
  - `internalMetricsSocketPath` - This is the full path to a UNIX domain socket
 	 that the Smart Agent will listen on for requests from the
-	 [internal-metrics](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/internal-metrics.md) monitor to gather
+	 <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/internal-metrics.md">internal-metrics</a> monitor to gather
 	 internal metrics about the Smart Agent.  It can also be blank to disable this
 	 socket.
 
@@ -195,12 +195,12 @@ capabilities the Smart Agent requires.
 `signalfx-agent/bin/signalfx-agent -config <path to config.yaml>`.  The Smart Agent
 logs only to stdout/err so it is up to you to direct that to a log file or
 other log management system if you wish to persist logs.  See the
-[signalfx-agent command](https://github.com/signalfx/signalfx-agent/tree/master/docs/signalfx-agent.1.man) doc for more information on
+<a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/signalfx-agent.1.man">signalfx-agent command</a> doc for more information on
 supported command flags.
 
 #### Privileges
 
-When using the [host observer](https://github.com/signalfx/signalfx-agent/tree/master/docs/observers/host.md), the Smart Agent requires
+When using the <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/observers/host.md">host observer</a>, the Smart Agent requires
 the [Linux
 capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html)
 `DAC_READ_SEARCH` and `SYS_PTRACE`, both of which are necessary to allow the
@@ -220,7 +220,7 @@ The Smart Agent is configured primarily from a YAML file (by default,
 `/etc/signalfx/agent.yaml`, but this can be overridden by the `-config` command
 line flag).  
 
-For the full schema of the config, see [Config Schema](https://github.com/signalfx/signalfx-agent/tree/master/docs/config-schema.md).
+For the full schema of the config, see <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/config-schema.md">Config Schema</a>.
 
 For information on how to configure the Smart Agent from remote sources, such as
 other files on the filesystem or KV stores such as Etcd, see [Remote
@@ -274,7 +274,7 @@ The Smart Agent status output has the following sections:
 	 generally does not prevent the Smart Agent from starting up, but will prevent
 	 that monitor from ever instantiating.
 
-Also see our [FAQ](https://github.com/signalfx/signalfx-agent/tree/master/docs/faq.md) for more troubleshooting help.
+Also see our <a target="_blank" href="https://github.com/signalfx/signalfx-agent/tree/master/docs/faq.md">FAQ</a> for more troubleshooting help.
 
 ### DEVELOPMENT
 

--- a/signalfx-metadata/README.md
+++ b/signalfx-metadata/README.md
@@ -1,6 +1,6 @@
 # SignalFx plugin for collectd
 
-Metadata associated with the SignalFx plugin for collectd can be found [here](https://github.com/signalfx/integrations/tree/release/signalfx-metadata). The relevant code for the plugin can be found [here](https://github.com/signalfx/collectd-signalfx/).
+Metadata associated with the SignalFx plugin for collectd can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/signalfx-metadata">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/collectd-signalfx/">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -30,7 +30,7 @@ This plugin requires:
 
         https://github.com/signalfx/signalfx-collectd-plugin
 
-2. Download SignalFx’s [sample configuration file](https://github.com/signalfx/integrations/blob/master/signalfx-metadata/10-signalfx.conf).
+2. Download SignalFx’s <a target="_blank" href="https://github.com/signalfx/integrations/blob/master/signalfx-metadata/10-signalfx.conf">sample configuration file</a>.
 
 3. Modify the configuration file as follows:
 
@@ -59,7 +59,7 @@ Directions for finding your token:
 | configuration option | definition | default value |
 | ---------------------|------------|---------------|
 | ModulePath | Path on disk where collectd can find this module. | "/opt/signalfx-collectd-plugin" |
-| URL | URL for where metrics are sent from collectd. If you are looking to limit the number of connections from your infrastructure to the SignalFx service you can optioally configure the use of the [SignalFx metricproxy](https://github.com/signalfx/integrations/tree/master/metricproxy) | "https://ingest.signalfx.com/v1/collectd" |
+| URL | URL for where metrics are sent from collectd. If you are looking to limit the number of connections from your infrastructure to the SignalFx service you can optioally configure the use of the <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/metricproxy">SignalFx metricproxy</a> | "https://ingest.signalfx.com/v1/collectd" |
 | Token | API token for your SignalFx org | none |
 | LogTraces | Enable log traces | true |
 | Notifications | Enable notification on this plugin | true |

--- a/telegraf/README.md
+++ b/telegraf/README.md
@@ -1,6 +1,6 @@
 # ![](https://github.com/signalfx/integrations/blob/master/telegraf/img/integrations_telegraf.png) SignalFx Telegraf Agent
 
-Metadata associated with the SignalFx Telegraf Agent can be found [here](https://github.com/signalfx/integrations/tree/release/telegraf). The code repository for this project can be found [here](https://github.com/signalfx/telegraf/).
+Metadata associated with the SignalFx Telegraf Agent can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/telegraf">here</a>. The code repository for this project can be found <a target="_blank" href="https://github.com/signalfx/telegraf/">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/vmware-vsphere/README.md
+++ b/vmware-vsphere/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_vsphere.png) vSphere
 
-Metadata associated with SignalFx's vSphere integration can be found [here](https://github.com/signalfx/integrations/tree/release/vmware-vsphere). The relevant code for the plugin can be found [here](https://github.com/signalfx/signalfx-vsphere/tree/master).
+Metadata associated with SignalFx's vSphere integration can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/vmware-vsphere">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/signalfx-vsphere/tree/master">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -71,7 +71,7 @@ This is the SignalFx vSphere integration. It collects metrics from vCenter and r
 
 6. Perform basic checks for network connectivity of VM by ```$ service vsphere-monitor check```
 
-7. If the version of the vCenter is less than 6.5, please check the aritcle [https://kb.vmware.com/s/article/2107096](https://kb.vmware.com/s/article/2107096) to increase the volume of metrics sent by vCenter.
+7. If the version of the vCenter is less than 6.5, please check the article <a target="_blank" href="https://kb.vmware.com/s/article/2107096">https://kb.vmware.com/s/article/2107096</a> to increase the volume of metrics sent by vCenter.
 
 8. Restart the service by  ```$ service vsphere-monitor restart```
 

--- a/win-perfcounter/README.md
+++ b/win-perfcounter/README.md
@@ -119,7 +119,7 @@ The names of all counters to be reported are combined together from all the conf
 
 NLog is used for logging, and the default configuration of this tool ships with just file logging enabled.  The logs are written to `%ALLUSERSPROFILE%\PerfCounterReporter\logs`.  Generally speaking, on modern Windows installations, this will be `C:\ProgramData\PerfCounterReporter\logs`.  
 
-For information on logging see [NLog documentation](http://nlog-project.org/wiki/Configuration_File).
+For information on logging see <a target="_blank" href="http://nlog-project.org/wiki/Configuration_File">NLog documentation</a>.
 
 ### LICENSE
 


### PR DESCRIPTION
This is for https://signalfuse.atlassian.net/browse/LIONS-295. 

It appears that the markdown syntax such as `[text](URL)` or `URL` opens in the same tab, where in many places we would like these links to open in a new tab or window. 

This PR changes most of the URLs in markdown syntax to vanilla HTML syntax `<a target="_blank" href="URL">`