### PR TITLE
added version to detector metric

### DIFF
--- a/signalfx-org-metrics/docs/sf.org.num.detector.md
+++ b/signalfx-org-metrics/docs/sf.org.num.detector.md
@@ -7,6 +7,6 @@ metric_type: gauge
 
 Total number of detectors; includes detectors that are muted.
 
-Dimension(s): `orgId`
+Dimension(s): `orgId, version`
 
 Data Resolution: 15 minutes


### PR DESCRIPTION
The change will go out this week, currently detectors are either version 1 or version 2