### PR TITLE
smart-gateway: fix the green tick and download link issue

### DIFF
--- a/signalfx-smart-gateway/README.md
+++ b/signalfx-smart-gateway/README.md
@@ -19,7 +19,7 @@ Please refer to the the sizing details located <a target="_blank" href="https://
 
 ### INSTALLATION
 
-You will want to download the Smart Gateway binary at <a target="_blank" href="https://app.signalfx.com/#/smart-gateway/download">https://app.signalfx.com/#/smart-gateway/download</a>
+You will want to download the Smart Gateway binary at <a target="_blank" href="/#/smart-gateway/download">here</a>.
 
 To deploy the SignalFx Smart Gateway, start by reviewing the <a target="_blank" href="https://docs.signalfx.com/en/latest/apm/apm-deployment/smart-gateway.html#instance-sizing">sizing information</a> to determine the recommended hardware for running the Smart Gateway.
 

--- a/signalfx-smart-gateway/meta.yaml
+++ b/signalfx-smart-gateway/meta.yaml
@@ -5,7 +5,7 @@
   "sort_order": 0,
   "logo_large": "integration_smartgateway@2x.png",
   "logo_small": "integration_smartgateway.png",
-  "data_signature": "sf_metric:gateway.processedTraces",
+  "data_signature": "sf_metric:\"gateway.processedTraces\"",
   "in_app_categories": ["essential"],
   "feature": "apm",
 }


### PR DESCRIPTION
what are fixes?

green tick:
- when the gateway.processedTraces metric is present, the green tick should be shown.

download link:
- instead of hard-coding the host for the download link, the current host/realm should be used.