### PR TITLE
Fix external API links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In order to be added to the integration index, SignalFx validates each integrati
 
 1. Create and publish a integration for SignalFx.
  1. We have built an example <a target="_blank" href="https://github.com/signalfx/collectd-example/blob/master/example_plugin.py">collectd-based plugin</a> to help you get started.
- 1. For other data collector types you'll just need to make sure that you can direct the output to SignalFX and use one of our <a target="_blank" href="https://developers.signalfx.com/docs/signalfx-api-overview">supported formats</a>
+ 1. For other data collector types you'll just need to make sure that you can direct the output to SignalFX and use one of our <a target="_blank" href="https://developers.signalfx.com/">supported formats</a>
 1. Ensure that your plugin meets the validation requirements - more on that below.
 1. Clone <a target="_blank" href="https://github.com/signalfx/Integrations">this repository</a> locally.
 1. Create a directory in this repository named after your plugin.

--- a/azure-kubernetes-service/README.md
+++ b/azure-kubernetes-service/README.md
@@ -1,4 +1,4 @@
-# ![](./img/integration_azurekubernetesservice.png) Microsoft Azure Virtual Machine Scale Sets
+# ![](./img/integration_azurekubernetesservice.png) Microsoft Azure Kubernetes Service
 
 - [Description](#description)
 - [Installation](#installation)

--- a/lib-java/README.md
+++ b/lib-java/README.md
@@ -32,7 +32,7 @@ Java 6+ with `signalfx-metrics`.
 #### API access token
 
 
-To use this library, you need a SignalFx API access token. <a target="_blank" href="https://developers.signalfx.com/docs/authentication">Click here for more information on retrieving an API token</a>.
+To use this library, you need a SignalFx API access token. <a target="_blank" href="https://developers.signalfx.com/administration/access_tokens_overview.html">Click here for more information on retrieving an API token</a>.
 
 
 ### INSTALLATION

--- a/lib-node/README.md
+++ b/lib-node/README.md
@@ -22,7 +22,7 @@
 
 #### API access token
 
-To use this library, you need a SignalFx API access token. <a target="_blank" href="https://developers.signalfx.com/docs/authentication">Click here for more information on retrieving your API token</a>.
+To use this library, you need a SignalFx API access token. <a target="_blank" href="https://developers.signalfx.com/administration/access_tokens_overview.html">Click here for more information on retrieving your API token</a>.
 
 
 ### INSTALLATION

--- a/lib-python/README.md
+++ b/lib-python/README.md
@@ -29,7 +29,7 @@ Python 2.7.9 or higher is recommended. If you are not making API calls to intera
 #### API access token
 
 To use this library, you need a SignalFx API access
-token. <a target="_blank" href="https://developers.signalfx.com/docs/authentication">Click here for more information on retrieving your API token</a>.
+token. <a target="_blank" href="https://developers.signalfx.com/administration/access_tokens_overview.html">Click here for more information on retrieving your API token</a>.
 
 ### INSTALLATION
 

--- a/lib-ruby/README.md
+++ b/lib-ruby/README.md
@@ -28,7 +28,7 @@ This library supports Ruby 2.x.
 #### API access token
 
 To use this library, you need a SignalFx API access
-token. <a target="_blank" href="https://developers.signalfx.com/docs/authentication-overview">Click here for more information on retrieving your API token</a>.
+token. <a target="_blank" href="https://developers.signalfx.com/administration/access_tokens_overview.html">Click here for more information on retrieving your API token</a>.
 
 
 ### INSTALLATION


### PR DESCRIPTION
We have a a new and improved developers.signalfx.com. Unfortunately some of our links broke. This fixes them.