### PR TITLE
integrations: Update Data Signatures for kafka, cassandra and activemq

### DIFF
--- a/collectd-activemq/meta.yaml
+++ b/collectd-activemq/meta.yaml
@@ -5,6 +5,6 @@
   "featured": true,
   "logo_large": "/images/repos/collectd-activemq/img/integrations_activemq%402x.png",
   "logo_small": "/images/repos/collectd-activemq/img/integrations_activemq.png",
-  "data_signature": "sf_metric:\"gauge.amq.TotalConsumerCount\"",
+  "data_signature": "hostHasService:activemq",
   "in_app_categories": ["servicesMonitored"]
 }

--- a/collectd-cassandra/meta.yaml
+++ b/collectd-cassandra/meta.yaml
@@ -5,6 +5,6 @@
   "featured": true,
   "logo_large": "/images/repos/collectd-cassandra/img/integrations_cassandra%402x.png",
   "logo_small": "/images/repos/collectd-cassandra/img/integrations_cassandra.png",
-  "data_signature": "sf_metric:\"gauge.cassandra.ClientRequest.Read.Latency.50thPercentile\"",
+  "data_signature": "hostHasService:cassandra",
   "in_app_categories": ["servicesMonitored"]
 }

--- a/collectd-kafka/meta.yaml
+++ b/collectd-kafka/meta.yaml
@@ -5,6 +5,6 @@
   "featured": true,
   "logo_small": "/images/repos/collectd-kafka/img/integrations_kafka.png",
   "logo_large": "/images/repos/collectd-kafka/img/integrations_kafka%402x.png",
-  "data_signature": "sf_metric:\"counter.kafka-messages-in\"",
+  "data_signature": "hostHasService:kafka",
   "in_app_categories": ["servicesMonitored"]
 }


### PR DESCRIPTION
As part of the new metric search, `data_signature` key will be used to filter metrics by integration. Update the kafka, cassandra and activemq to correct data signatures instead of `sf_metric`

Issue: https://signalfuse.atlassian.net/browse/LIONS-894