### PR TITLE
Update data signitures for agents

### DIFF
--- a/collectd/meta.yaml
+++ b/collectd/meta.yaml
@@ -1,5 +1,5 @@
 code: https://github.com/signalfx/collectd
-data_signature: plugin:"signalfx-metadata"
+data_signature: _exists_:"depricated_check"
 description: SignalFx's build of collectd, the open-source metrics collection agent.
 display_name: SignalFx collectd agent
 featured: true

--- a/signalfx-agent/meta.yaml
+++ b/signalfx-agent/meta.yaml
@@ -1,5 +1,5 @@
 code: https://github.com/signalfx/signalfx-agent
-data_signature: _exists_:signalfx_agent
+data_signature: plugin:host-metadata
 description: SignalFx's newer agent with auto-discovery that supersedes our old collectd
   agent
 display_name: ' SignalFx SmartAgent'

--- a/signalfx-agent/meta.yaml
+++ b/signalfx-agent/meta.yaml
@@ -1,5 +1,5 @@
 code: https://github.com/signalfx/signalfx-agent
-data_signature: plugin:host-metadata
+data_signature: plugin:"host-metadata"
 description: SignalFx's newer agent with auto-discovery that supersedes our old collectd
   agent
 display_name: ' SignalFx SmartAgent'


### PR DESCRIPTION
Feedback from the field & customers was that upon installing the smart agent, there was confusion why the old "signalfx collectd agent" was getting a ✅  instead of the smart agent.

As we are moving forward to being smart-agent centric, and updating all docs to be smart agent centric, we should make sure the ✅  appears on the smart-agent tile on the integrations page.

The data signiture `plugin:host-metadata` comes from a default, smart-agent only monitor so this should be a good identifier as to when the agent has been installed.

For the old collectd agent, using the `_exists_:depricated_check` should always null out and never supply a ✅ for that tile.