### PR TITLE
1295 pg google tiles

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -8,7 +8,7 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Cloud Platform (GCP) services via StackDriver Monitoring. This integration enables data collection from all GCP web services that report to StackDriver.
+Use SignalFx to monitor Google Cloud Platform (GCP) services through StackDriver Monitoring. This integration enables data collection from all GCP web services that report to StackDriver.
 
 ### FEATURES
 

--- a/google-appengine/README.md
+++ b/google-appengine/README.md
@@ -8,7 +8,7 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google App Engine via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google App Engine through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
 ### FEATURES
 

--- a/google-appengine/README.md
+++ b/google-appengine/README.md
@@ -10,7 +10,7 @@
 
 Use SignalFx to monitor Google App Engine via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -128,10 +128,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google App Engine, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-appengine">https://cloud.google.com/monitoring/api/metrics#gcp-appengine</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-bigquery/README.md
+++ b/google-bigquery/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google BigQuery via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google BigQuery through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -51,10 +51,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 - **Rows Uploaded / min per Table** - List number of rows uploaded per min aggregated by table.
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google BigQuery, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-bigquery">https://cloud.google.com/monitoring/api/metrics#gcp-bigquery</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Cloud Bigtable via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Cloud Bigtable through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -160,10 +160,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
 - **Disk Bytes Used** - Amount of disk used by the table
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Cloud Bigtable, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-bigtable">https://cloud.google.com/monitoring/api/metrics#gcp-bigtable</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Cloud Datastore via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Cloud Datastore through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -45,10 +45,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
   [<img src='./img/datastore-overview-read-sizes-type.png' width=200px>](./img/datastore-overview-read-sizes-type.png)
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Cloud Datastore, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-datastore">https://cloud.google.com/monitoring/api/metrics#gcp-datastore</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-cloud-functions/README.md
+++ b/google-cloud-functions/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Cloud Functions via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Cloud Functions through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -67,10 +67,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
   [<img src='./img/functions-overview-exec-times.png' width=200px>](./img/functions-overview-exec-times.png)
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Cloud Functions, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-cloudfunctions">https://cloud.google.com/monitoring/api/metrics#gcp-cloudfunctions</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Cloud Pub/Sub via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Cloud Pub/Sub through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -108,10 +108,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
   [<img src='./img/topic-average-message-size.png' width=200px>](./img/topic-average-message-size.png)
 
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Cloud Pub/Sub, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-pubsub">https://cloud.google.com/monitoring/api/metrics#gcp-pubsub</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-cloud-router/README.md
+++ b/google-cloud-router/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Cloud Router via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Cloud Router through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -87,10 +87,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
   [<img src='./img/router-overview-routes-sent-per-router.png' width=200px>](./img/router-overview-routes-sent-per-router.png)
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Cloud Router, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-router">https://cloud.google.com/monitoring/api/metrics#gcp-router</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-cloud-spanner/README.md
+++ b/google-cloud-spanner/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Cloud Spanner via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Cloud Spanner through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -78,10 +78,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
   [<img src='./img/overview-storage-used.png' width=200px>](./img/overview-storage-used.png)
 
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Cloud Spanner, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-spanner">https://cloud.google.com/monitoring/api/metrics#gcp-spanner</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Cloud Storage via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Cloud Storage through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -66,10 +66,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 - **Sent Bytes per Bucket** - Lists total bytes sent by each bucket.
 
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Cloud Storage, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-storage">https://cloud.google.com/monitoring/api/metrics#gcp-storage</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-compute-engine/README.md
+++ b/google-compute-engine/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Compute Engine via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Compute Engine through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -118,10 +118,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
 
   [<img src='./img/instances-network-bytes-out-vs-change.png' width=200px>](./img/instances-network-bytes-out-vs-change.png)
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Compute Engine, visit the service's metric page at <a target="_blank" href="https://cloud.google.com/monitoring/api/metrics#gcp-compute">https://cloud.google.com/monitoring/api/metrics#gcp-compute</a>
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.

--- a/google-container-engine/README.md
+++ b/google-container-engine/README.md
@@ -8,9 +8,9 @@
 
 ### DESCRIPTION
 
-Use SignalFx to monitor Google Container Engine via [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
+Use SignalFx to monitor Google Container Engine through [Google Cloud Platform](https://github.com/signalfx/integrations/tree/master/gcp)[](sfx_link:gcp).
 
-#### FEATURES
+### FEATURES
 
 ##### Built-in dashboards
 
@@ -116,10 +116,10 @@ To access this integration, [connect to Google Cloud Platform](https://github.co
   [<img src='./img/pod-major-page-faults-per-container.png' width=200px>](./img/pod-major-page-faults-per-container.png)
 
 
-### METRICS
+#### METRICS
 
 For more information about the metrics emitted by Google Container Engine, visit [the service's metric page](https://cloud.google.com/monitoring/api/metrics#gcp-container).
 
-### LICENSE
+#### LICENSE
 
 This integration is released under the Apache 2.0 license. See [LICENSE](./LICENSE) for more details.


### PR DESCRIPTION
JIRA: https://signalfuse.atlassian.net/browse/DOCS-1295

Updated headers to: 

- remove duplicated "features" from "overview" tab
- make "license" and "metrics" visible in the tile
- replaced "via" with "through"