### PR TITLE
Update meta.yaml description text

### DIFF
--- a/telegraf/meta.yaml
+++ b/telegraf/meta.yaml
@@ -1,6 +1,6 @@
 code: https://github.com/signalfx/telegraf
 data_signature: agent:"telegraf"
-description: SignalFx's build of telegraf, the open-source metrics collection agent.
+description: SignalFx build of Telegraf, the open-source metrics collection agent.
 display_name: SignalFx Telegraf agent
 featured: false
 in_app_categories:


### PR DESCRIPTION
Removed possessive use of company name (SignalFx's) to conform with Splunk style and simplify legal and trademark issues. Initial capped the T in Telegraf for consistency with documentation for that integration.