### PR TITLE
Add useLegacyBuild to all integrations

### DIFF
--- a/Example/meta.yaml
+++ b/Example/meta.yaml
@@ -4,3 +4,4 @@ display_name: Example Python Plugin
 featured: true
 logo_large: https://myavantiservices.files.wordpress.com/2015/02/helloworld%402x.gif
 logo_small: https://myavantiservices.files.wordpress.com/2015/02/helloworld.gif
+useLegacyBuild: true

--- a/activemq/meta.yaml
+++ b/activemq/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/activemq/img/integrations_activemq%402x.png
 logo_small: /images/repos/activemq/img/integrations_activemq.png
 project_url: https://github.com/signalfx/integrations/tree/master/activemq
+useLegacyBuild: true

--- a/amq-message-age/meta.yaml
+++ b/amq-message-age/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integrations_activemq%402x.png
 logo_small: integrations_activemq.png
 project_url: https://github.com/signalfx/integrations/tree/master/amq-message-age
+useLegacyBuild: true

--- a/apache/meta.yaml
+++ b/apache/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/apache/img/integrations_apache%402x.png
 logo_small: /images/repos/apache/img/integrations_apache.png
 project_url: https://github.com/signalfx/integrations/tree/master/apache
+useLegacyBuild: true

--- a/appdynamics/meta.yaml
+++ b/appdynamics/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/appdynamics/img/integrations_appdynamics%402x.png
 logo_small: /images/repos/appdynamics/img/integrations_appdynamics.png
 project_url: https://github.com/signalfx/integrations/tree/master/appdynamics
+useLegacyBuild: true

--- a/aws-alb/meta.yaml
+++ b/aws-alb/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awsalb.png
 logo_small: integration_awsalb.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-alb
+useLegacyBuild: true

--- a/aws-api-gateway/meta.yaml
+++ b/aws-api-gateway/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integration_awsapigateway@2x.png
 logo_small: integration_awsapigateway.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-api-gateway
+useLegacyBuild: true

--- a/aws-autoscaling/meta.yaml
+++ b/aws-autoscaling/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awsautoscaling.png
 logo_small: integration_awsautoscaling.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-autoscaling
+useLegacyBuild: true

--- a/aws-cloudfront/meta.yaml
+++ b/aws-cloudfront/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awscloudfront.png
 logo_small: integration_awscloudfront.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-cloudfront
+useLegacyBuild: true

--- a/aws-cloudwatch-events/meta.yaml
+++ b/aws-cloudwatch-events/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integration_cloudwatchevents%402x.png
 logo_small: integration_cloudwatchevents.png
 project_url: https://github.com/signalfx/cloudwatch-event-forwarder/blob/master/README.md
+useLegacyBuild: true

--- a/aws-dynamodb/meta.yaml
+++ b/aws-dynamodb/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awsdynamodb%402x.png
 logo_small: integration_awsdynamodb.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-dynamodb
+useLegacyBuild: true

--- a/aws-ebs/meta.yaml
+++ b/aws-ebs/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awsebs.png
 logo_small: integration_awsebs.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-ebs
+useLegacyBuild: true

--- a/aws-ec2/meta.yaml
+++ b/aws-ec2/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awsec2.png
 logo_small: integration_awsec2.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-ec2
+useLegacyBuild: true

--- a/aws-ecs/meta.yaml
+++ b/aws-ecs/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integration_awsecs.png
 logo_small: integration_awsecs.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-ecs
+useLegacyBuild: true

--- a/aws-eks/meta.yaml
+++ b/aws-eks/meta.yaml
@@ -12,3 +12,4 @@ in_app_categories:
 logo_large: integration_amazoneks%402x.png
 logo_small: integration_amazoneks.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-eks
+useLegacyBuild: true

--- a/aws-elasticache/meta.yaml
+++ b/aws-elasticache/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awselasticache.png
 logo_small: integration_awselasticache.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-elasticache
+useLegacyBuild: true

--- a/aws-elb/meta.yaml
+++ b/aws-elb/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awselb.png
 logo_small: integration_awselb.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-elb
+useLegacyBuild: true

--- a/aws-kinesis-analytics/meta.yaml
+++ b/aws-kinesis-analytics/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integration_awskinesisanalytics%402x.png
 logo_small: integration_awskinesisanalytics.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-kinesis-analytics
+useLegacyBuild: true

--- a/aws-kinesis-streams/meta.yaml
+++ b/aws-kinesis-streams/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integration_awskinesisstreams%402x.png
 logo_small: integration_awskinesisstreams.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-kinesis-streams
+useLegacyBuild: true

--- a/aws-lambda/meta.yaml
+++ b/aws-lambda/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awslambda%402x.png
 logo_small: integration_awslambda.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-lambda
+useLegacyBuild: true

--- a/aws-opsworks/meta.yaml
+++ b/aws-opsworks/meta.yaml
@@ -8,3 +8,4 @@ in_app_categories:
 logo_large: integration_awsopsworks.png
 logo_small: integration_awsopsworks.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-opsworks
+useLegacyBuild: true

--- a/aws-optimizer/meta.yaml
+++ b/aws-optimizer/meta.yaml
@@ -7,3 +7,4 @@ in_app_categories:
 logo_large: integration_optimizer.png
 logo_small: integration_optimizer.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-optimizer
+useLegacyBuild: true

--- a/aws-rds/meta.yaml
+++ b/aws-rds/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awsrds.png
 logo_small: integration_awsrds.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-rds
+useLegacyBuild: true

--- a/aws-redshift/meta.yaml
+++ b/aws-redshift/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awsredshift%402x.png
 logo_small: integration_awsredshift.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-redshift
+useLegacyBuild: true

--- a/aws-route53/meta.yaml
+++ b/aws-route53/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awsroute53.png
 logo_small: integration_awsroute53.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-route53
+useLegacyBuild: true

--- a/aws-sns/meta.yaml
+++ b/aws-sns/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awssns.png
 logo_small: integration_awssns.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-sns
+useLegacyBuild: true

--- a/aws-sqs/meta.yaml
+++ b/aws-sqs/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_awssqs.png
 logo_small: integration_awssqs.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws-sqs
+useLegacyBuild: true

--- a/aws/meta.yaml
+++ b/aws/meta.yaml
@@ -11,3 +11,4 @@ logo_large: integration_aws.png
 logo_small: integration_aws.png
 project_url: https://github.com/signalfx/integrations/tree/master/aws
 sort_order: 2
+useLegacyBuild: true

--- a/azure-app-service/meta.yaml
+++ b/azure-app-service/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integrations_azureappservice%402x.png
 logo_small: integrations_azureappservice.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-app-service
+useLegacyBuild: true

--- a/azure-batch/meta.yaml
+++ b/azure-batch/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integrations_azurebatch%402x.png
 logo_small: integrations_azurebatch.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-batch
+useLegacyBuild: true

--- a/azure-event-hubs/meta.yaml
+++ b/azure-event-hubs/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integrations_azureeventhubs%402x.png
 logo_small: integrations_azureeventhubs.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-event-hubbs
+useLegacyBuild: true

--- a/azure-functions/meta.yaml
+++ b/azure-functions/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_azurefunctions@2x.png
 logo_small: integration_azurefunctions.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-functions
+useLegacyBuild: true

--- a/azure-kubernetes-service/meta.yaml
+++ b/azure-kubernetes-service/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_azurekubernetesservice%402x.png
 logo_small: integration_azurekubernetesservice.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-kubernetes-service
+useLegacyBuild: true

--- a/azure-logic-app/meta.yaml
+++ b/azure-logic-app/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integrations_azurelogicapps%402x.png
 logo_small: integrations_azurelogicapps.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-logic-app
+useLegacyBuild: true

--- a/azure-redis/meta.yaml
+++ b/azure-redis/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integrations_azurerediscaches%402x.png
 logo_small: integrations_azurerediscaches.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-redis
+useLegacyBuild: true

--- a/azure-sql-databases/meta.yaml
+++ b/azure-sql-databases/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integrations_azuresqldatabase%402x.png
 logo_small: integrations_azuresqldatabase.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-sql-databases
+useLegacyBuild: true

--- a/azure-sql-elasticpools/meta.yaml
+++ b/azure-sql-elasticpools/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integrations_azuresqlelasticpools%402x.png
 logo_small: integrations_azuresqlelasticpools.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-sql-elasticpools
+useLegacyBuild: true

--- a/azure-storage/meta.yaml
+++ b/azure-storage/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integrations_azurestorage%402x.png
 logo_small: integrations_azurestorage.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-storage
+useLegacyBuild: true

--- a/azure-vm/meta.yaml
+++ b/azure-vm/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integrations_azurevm%402x.png
 logo_small: integrations_azurevm.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-vm
+useLegacyBuild: true

--- a/azure-vmscaleset/meta.yaml
+++ b/azure-vmscaleset/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integrations_azurevmscaleset%402x.png
 logo_small: integrations_azurevmscaleset.png
 project_url: https://github.com/signalfx/integrations/tree/master/azure-vmscaleset
+useLegacyBuild: true

--- a/azure/meta.yaml
+++ b/azure/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integrations_azure.png
 logo_small: integrations_azure.png
 project_url: https://github.com/signalfx/integrations/tree/master/microsoft-azure
+useLegacyBuild: true

--- a/cassandra/meta.yaml
+++ b/cassandra/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/collectd-cassandra/img/integrations_cassandra%402x.png
 logo_small: /images/repos/collectd-cassandra/img/integrations_cassandra.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-cassandra
+useLegacyBuild: true

--- a/check-links
+++ b/check-links
@@ -6,5 +6,5 @@ liche --recursive \
   --concurrency 50 \
   --timeout 30 \
   --document-root / \
-  --exclude '(localhost|leader\.mesos|YOUR_SIGNALFX_ORG_ID|YOUR_SIGNALFX_REALM|ingest.*signalfx.com|127\.0\.0\.1|kb\.vmware\.com|support\.signalfx\.com|signalfx-agent/agent_docs|169\.254\.170\.2)' \
+  --exclude '(localhost|leader\.mesos|YOUR_SIGNALFX_ORG_ID|YOUR_SIGNALFX_REALM|ingest.*signalfx.com|127\.0\.0\.1|kb\.vmware\.com|support\.signalfx\.com|signalfx-agent/agent_docs|169\.254\.170\.2|log-stream)' \
   .

--- a/cloudfoundry-generic/meta.yaml
+++ b/cloudfoundry-generic/meta.yaml
@@ -8,3 +8,4 @@ in_app_categories:
 logo_large: /images/repos/cloudfoundry/img/integrations_cloudfoundry%402x.png
 logo_small: /images/repos/cloudfoundry/img/integrations_cloudfoundry.png
 project_url: https://github.com/signalfx/integrations/tree/master/cloudfoundry
+useLegacyBuild: true

--- a/cloudfoundry-pivotal/meta.yaml
+++ b/cloudfoundry-pivotal/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/cloudfoundry/img/integrations_pivotalcloudfoundry%402x.png
 logo_small: /images/repos/cloudfoundry/img/integrations_pivotalcloudfoundry.png
 project_url: https://github.com/signalfx/integrations/tree/master/cloudfoundry-pivotal
+useLegacyBuild: true

--- a/collectd-couchdb/meta.yaml
+++ b/collectd-couchdb/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/collectd-couchdb/img/integrations_couchdb%402x.png
 logo_small: /images/repos/collectd-couchdb/img/integrations_couchdb.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-couchdb
+useLegacyBuild: true

--- a/collectd-cpu/meta.yaml
+++ b/collectd-cpu/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/collectd/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-cpu
+useLegacyBuild: true

--- a/collectd-curl-json/meta.yaml
+++ b/collectd-curl-json/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/collectd/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-curl-json
+useLegacyBuild: true

--- a/collectd-df/meta.yaml
+++ b/collectd-df/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/collectd/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-df
+useLegacyBuild: true

--- a/collectd-disk/meta.yaml
+++ b/collectd-disk/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/collectd/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-disk
+useLegacyBuild: true

--- a/collectd-hbase/meta.yaml
+++ b/collectd-hbase/meta.yaml
@@ -7,3 +7,4 @@ featured: false
 logo_large: /images/repos/collectd-hbase/img/integrations_hbase%402x.png
 logo_small: /images/repos/collectd-hbase/img/integrations_hbase.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-hbase
+useLegacyBuild: true

--- a/collectd-interface/meta.yaml
+++ b/collectd-interface/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/collectd/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-interface
+useLegacyBuild: true

--- a/collectd-iostat/meta.yaml
+++ b/collectd-iostat/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/collectd-docker/img/integrations_iostat%402x.png
 logo_small: /images/repos/collectd-docker/img/integrations_iostat.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-iostat
+useLegacyBuild: true

--- a/collectd-load/meta.yaml
+++ b/collectd-load/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/collectd/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-load
+useLegacyBuild: true

--- a/collectd-memory/meta.yaml
+++ b/collectd-memory/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/collectd-memory/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd-memory/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-memory
+useLegacyBuild: true

--- a/collectd-mesos/meta.yaml
+++ b/collectd-mesos/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: /images/repos/collectd-mesos/img/integrations_mesos%402x.png
 logo_small: /images/repos/collectd-mesos/img/integrations_mesos.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-mesos
+useLegacyBuild: true

--- a/collectd-nginx-plus/meta.yaml
+++ b/collectd-nginx-plus/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/collectd-nginx-plus/img/integrations_nginxplus%402x.png
 logo_small: /images/repos/collectd-nginx-plus/img/integrations_nginxplus.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-nginx-plus
+useLegacyBuild: true

--- a/collectd-protocols/meta.yaml
+++ b/collectd-protocols/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/collectd-protocols/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd-protocols/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-protocols
+useLegacyBuild: true

--- a/collectd-riak/meta.yaml
+++ b/collectd-riak/meta.yaml
@@ -7,3 +7,4 @@ featured: true
 logo_large: /images/repos/collectd-riak/img/integrations_riak%402x.png
 logo_small: /images/repos/collectd-riak/img/integrations_riak.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-riak
+useLegacyBuild: true

--- a/collectd-tail-syslog/meta.yaml
+++ b/collectd-tail-syslog/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/collectd-tail-syslog/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd-tail-syslog/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-tail-syslog
+useLegacyBuild: true

--- a/collectd-uptime/meta.yaml
+++ b/collectd-uptime/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/collectd-uptime/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd-uptime/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-uptime
+useLegacyBuild: true

--- a/collectd-varnish/meta.yaml
+++ b/collectd-varnish/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/collectd-varnish/img/integrations_varnish%402x.png
 logo_small: /images/repos/collectd-varnish/img/integrations_varnish.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-varnish
+useLegacyBuild: true

--- a/collectd-vmem/meta.yaml
+++ b/collectd-vmem/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/collectd-vmem/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd-vmem/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-vmem
+useLegacyBuild: true

--- a/collectd-vmstat/meta.yaml
+++ b/collectd-vmstat/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/collectd-docker/img/integrations_vmstat%402x.png
 logo_small: /images/repos/collectd-docker/img/integrations_vmstat.png
 project_url: https://github.com/signalfx/integrations/tree/master/vmstat-collectd
+useLegacyBuild: true

--- a/collectd-write_http/meta.yaml
+++ b/collectd-write_http/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/collectd-write_http/img/integrations_collectd%402x.png
 logo_small: /images/repos/collectd-write_http/img/integrations_collectd.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-write_http
+useLegacyBuild: true

--- a/collectd/meta.yaml
+++ b/collectd/meta.yaml
@@ -9,3 +9,4 @@ logo_large: /images/repos/collectd/img/integration_signalfx.png
 logo_small: /images/repos/collectd/img/integration_signalfx.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd
 sort_order: 1
+useLegacyBuild: true

--- a/consul/meta.yaml
+++ b/consul/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/collectd-consul/img/integrations_consul%402x.png
 logo_small: /images/repos/collectd-consul/img/integrations_consul.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-consul
+useLegacyBuild: true

--- a/conviva/meta.yaml
+++ b/conviva/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/conviva/img/integration_conviva@2x.png
 logo_small: /images/repos/conviva/img/integration_conviva.png
 project_url: https://github.com/signalfx/integrations/tree/master/conviva
+useLegacyBuild: true

--- a/couchbase/meta.yaml
+++ b/couchbase/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/collectd-couchbase/img/integrations_couchbase%402x.png
 logo_small: /images/repos/collectd-couchbase/img/integrations_couchbase.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-couchbase
+useLegacyBuild: true

--- a/customurl/meta.yaml
+++ b/customurl/meta.yaml
@@ -8,3 +8,4 @@ in_app_categories:
 logo_large: integration_externallink@2x.png
 logo_small: integration_externallink.png
 project_url: https://github.com/signalfx/integrations/tree/master/customurl
+useLegacyBuild: true

--- a/docker/meta.yaml
+++ b/docker/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: /images/repos/docker/img/integrations_docker%402x.png
 logo_small: /images/repos/docker/img/integrations_docker.png
 project_url: https://github.com/signalfx/integrations/tree/master/docker
+useLegacyBuild: true

--- a/elastic-stack/meta.yaml
+++ b/elastic-stack/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integration_elastic_stack@2x.png
 logo_small: integration_elastic_stack.png
 project_url: https://github.com/signalfx/integrations/tree/master/elastic-statck
+useLegacyBuild: true

--- a/elasticsearch/meta.yaml
+++ b/elasticsearch/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/elasticsearch/img/integrations_elasticsearch%402x.png
 logo_small: /images/repos/elasticsearch/img/integrations_elasticsearch.png
 project_url: https://github.com/signalfx/integrations/tree/master/elasticsearch
+useLegacyBuild: true

--- a/etcd/meta.yaml
+++ b/etcd/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/etcd/img/integrations_etcd%402x.png
 logo_small: /images/repos/etcd/img/integrations_etcd.png
 project_url: https://github.com/signalfx/integrations/tree/master/etcd
+useLegacyBuild: true

--- a/expvar/meta.yaml
+++ b/expvar/meta.yaml
@@ -9,3 +9,4 @@ in_app_categories:
 logo_large: /images/repos/expvar/img/integration_expvar@2x.png
 logo_small: /images/repos/expvar/img/integration_expvar.png
 project_url: https://github.com/signalfx/integrations/tree/master/expvar
+useLegacyBuild: true

--- a/fluentbit/meta.yaml
+++ b/fluentbit/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/microsoft-iis/img/integration_fluentbit%402x.png
 logo_small: /images/repos/microsoft-iis/img/integration_fluentbit.png
 project_url: https://github.com/signalfx/fluent-bit-plugin/blob/master/README.md
+useLegacyBuild: true

--- a/gateway/meta.yaml
+++ b/gateway/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/gateway/img/integration_sfxgateway%402x.png
 logo_small: /images/repos/gateway/img/integration_sfxgateway.png
 project_url: https://github.com/signalfx/integrations/tree/master/gateway
+useLegacyBuild: true

--- a/gcp/meta.yaml
+++ b/gcp/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: integration_gcp.png
 logo_small: integration_gcp.png
 project_url: https://github.com/signalfx/integrations/tree/master/gcp
+useLegacyBuild: true

--- a/gitlab/meta.yaml
+++ b/gitlab/meta.yaml
@@ -9,3 +9,4 @@ in_app_categories:
 logo_large: /images/repos/gitlab/img/integration_gitlab@2x.png
 logo_small: /images/repos/gitlab/img/integration_gitlab.png
 project_url: https://github.com/signalfx/integrations/tree/master/gitlab
+useLegacyBuild: true

--- a/google-appengine/meta.yaml
+++ b/google-appengine/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googleappengine%402x.png
 logo_small: integration_googleappengine.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-appengine
+useLegacyBuild: true

--- a/google-bigquery/meta.yaml
+++ b/google-bigquery/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlebigquery%402x.png
 logo_small: integration_googlebigquery.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-bigquery
+useLegacyBuild: true

--- a/google-cloud-bigtable/meta.yaml
+++ b/google-cloud-bigtable/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlecloudbigtable%402x.png
 logo_small: integration_googlecloudbigtable.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-cloud-bigtable
+useLegacyBuild: true

--- a/google-cloud-datastore/meta.yaml
+++ b/google-cloud-datastore/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googleclouddatastore%402x.png
 logo_small: integration_googleclouddatastore.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-cloud-datastore
+useLegacyBuild: true

--- a/google-cloud-functions/meta.yaml
+++ b/google-cloud-functions/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlecloudfunctions%402x.png
 logo_small: integration_googlecloudfunctions.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-cloud-functions
+useLegacyBuild: true

--- a/google-cloud-pubsub/meta.yaml
+++ b/google-cloud-pubsub/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlecloudpubsub%402x.png
 logo_small: integration_googlecloudpubsub.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-cloud-pubsub
+useLegacyBuild: true

--- a/google-cloud-router/meta.yaml
+++ b/google-cloud-router/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlecloudrouter%402x.png
 logo_small: integration_googlecloudrouter.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-cloud-router
+useLegacyBuild: true

--- a/google-cloud-spanner/meta.yaml
+++ b/google-cloud-spanner/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlecloudspanner%402x.png
 logo_small: integration_googlecloudspanner.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-cloud-spanner
+useLegacyBuild: true

--- a/google-cloud-storage/meta.yaml
+++ b/google-cloud-storage/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlecloudstorage%402x.png
 logo_small: integration_googlecloudstorage.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-cloud-storage
+useLegacyBuild: true

--- a/google-compute-engine/meta.yaml
+++ b/google-compute-engine/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlecomputeengine%402x.png
 logo_small: integration_googlecomputeengine.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-compute-engine
+useLegacyBuild: true

--- a/google-container-engine/meta.yaml
+++ b/google-container-engine/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_googlecontainerengine%402x.png
 logo_small: integration_googlecontainerengine.png
 project_url: https://github.com/signalfx/integrations/tree/master/google-container-engine
+useLegacyBuild: true

--- a/hadoop/meta.yaml
+++ b/hadoop/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: /images/repos/hadoop/img/integrations_hadoop@2x.png
 logo_small: /images/repos/hadoop/img/integrations_hadoop.png
 project_url: https://github.com/signalfx/integrations/tree/master/hadoop
+useLegacyBuild: true

--- a/haproxy/meta.yaml
+++ b/haproxy/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/haproxy/img/integrations_haproxy%402x.png
 logo_small: /images/repos/haproxy/img/integrations_haproxy.png
 project_url: https://github.com/signalfx/integrations/tree/master/haproxy
+useLegacyBuild: true

--- a/heka-filter-signalfx/meta.yaml
+++ b/heka-filter-signalfx/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/heka-filter-signalfx/img/integrations_heka%402x.png
 logo_small: /images/repos/heka-filter-signalfx/img/integrations_heka.png
 project_url: https://github.com/signalfx/integrations/tree/master/heka-filter-signalfx
+useLegacyBuild: true

--- a/heroku/meta.yaml
+++ b/heroku/meta.yaml
@@ -9,3 +9,4 @@ in_app_categories:
 logo_large: /images/repos/etcd/img/integration_heroku@2x.png
 logo_small: /images/repos/etcd/img/integration_heroku.png
 project_url: https://github.com/signalfx/integrations/tree/master/heroku
+useLegacyBuild: true

--- a/java/meta.yaml
+++ b/java/meta.yaml
@@ -8,3 +8,4 @@ in_app_categories:
 logo_large: /images/repos/java/img/integrations_java%402x.png
 logo_small: /images/repos/java/img/integrations_java.png
 project_url: https://github.com/signalfx/integrations/tree/master/java
+useLegacyBuild: true

--- a/jenkins/meta.yaml
+++ b/jenkins/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/jenkins/img/integrations_jenkins%402x.png
 logo_small: /images/repos/jenkins/img/integrations_jenkins.png
 project_url: https://github.com/signalfx/integrations/tree/master/jenkins
+useLegacyBuild: true

--- a/kafka/meta.yaml
+++ b/kafka/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/kafka/img/integrations_kafka%402x.png
 logo_small: /images/repos/kafka/img/integrations_kafka.png
 project_url: https://github.com/signalfx/integrations/tree/master/kafka
+useLegacyBuild: true

--- a/kong/meta.yaml
+++ b/kong/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/kong/img/integrations_kong%402x.png
 logo_small: /images/repos/kong/img/integrations_kong.png
 project_url: https://github.com/signalfx/integrations/tree/master/kong
+useLegacyBuild: true

--- a/kubernetes/meta.yaml
+++ b/kubernetes/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: /images/repos/kubernetes/img/integrations_kubernetes%402x.png
 logo_small: /images/repos/kubernetes/img/integrations_kubernetes.png
 project_url: https://github.com/signalfx/integrations/tree/master/kubernetes
+useLegacyBuild: true

--- a/lib-go/meta.yaml
+++ b/lib-go/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/lib-go/img/integrations_golang%402x.png
 logo_small: /images/repos/lib-go/img/integrations_golang.png
 project_url: https://github.com/signalfx/integrations/tree/master/lib-go
+useLegacyBuild: true

--- a/lib-java/meta.yaml
+++ b/lib-java/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/lib-java/img/integrations_java%402x.png
 logo_small: /images/repos/lib-java/img/integrations_java.png
 project_url: https://github.com/signalfx/integrations/tree/master/lib-java
+useLegacyBuild: true

--- a/lib-node/meta.yaml
+++ b/lib-node/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/lib-node/img/integrations_nodejs%402x.png
 logo_small: /images/repos/lib-node/img/integrations_nodejs.png
 project_url: https://github.com/signalfx/integrations/tree/master/lib-node
+useLegacyBuild: true

--- a/lib-python/meta.yaml
+++ b/lib-python/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/lib-python/img/integrations_python%402x.png
 logo_small: /images/repos/lib-python/img/integrations_python.png
 project_url: https://github.com/signalfx/integrations/tree/master/lib-python
+useLegacyBuild: true

--- a/lib-ruby/meta.yaml
+++ b/lib-ruby/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/lib-ruby/img/integrations_tuby%402x.png
 logo_small: /images/repos/lib-ruby/img/integrations_ruby.png
 project_url: https://github.com/signalfx/integrations/tree/master/lib-ruby
+useLegacyBuild: true

--- a/logstash-ciscoxr/meta.yaml
+++ b/logstash-ciscoxr/meta.yaml
@@ -7,3 +7,4 @@ featured: true
 logo_large: /images/repos/logstash-ciscoxr/img/integrations_ciscoiosxr%402x.png
 logo_small: /images/repos/logstash-ciscoxr/img/integrations_ciscoiosxr.png
 project_url: https://github.com/signalfx/integrations/tree/master/logstash-ciscoxr
+useLegacyBuild: true

--- a/logstash/meta.yaml
+++ b/logstash/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/elasticsearch/img/integration_logstash%402x.png
 logo_small: /images/repos/elasticsearch/img/integration_logstash.png
 project_url: https://github.com/signalfx/integrations/tree/master/logstash
+useLegacyBuild: true

--- a/marathon/meta.yaml
+++ b/marathon/meta.yaml
@@ -11,3 +11,4 @@ in_app_categories:
 logo_large: /images/repos/docker/img/integrations_marathon%402x.png
 logo_small: /images/repos/docker/img/integrations_marathon.png
 project_url: https://github.com/signalfx/integrations/tree/master/marathon
+useLegacyBuild: true

--- a/memcached/meta.yaml
+++ b/memcached/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/memcached/img/integrations_memcached%402x.png
 logo_small: /images/repos/memcached/img/integrations_memcached.png
 project_url: https://github.com/signalfx/integrations/tree/master/memcached
+useLegacyBuild: true

--- a/metricproxy/meta.yaml
+++ b/metricproxy/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/metricproxy/img/integrations_metricproxy%402x.png
 logo_small: /images/repos/metricproxy/img/integrations_metricproxy.png
 project_url: https://github.com/signalfx/integrations/tree/master/metricproxy
+useLegacyBuild: true

--- a/microsoft-iis/meta.yaml
+++ b/microsoft-iis/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/microsoft-iis/img/integration_microsoftiis%402x.png
 logo_small: /images/repos/microsoft-iis/img/integration_microsoftiis.png
 project_url: https://github.com/signalfx/signalfx-agent/blob/master/docs/monitors/windows-iis.md
+useLegacyBuild: true

--- a/microsoft-sql-server/meta.yaml
+++ b/microsoft-sql-server/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/microsoft-sql-server/img/integration_microsoftsqlserver%402x.png
 logo_small: /images/repos/microsoft-sql-server/img/integration_microsoftsqlserver.png
 project_url: https://github.com/signalfx/signalfx-agent/blob/master/docs/monitors/telegraf-sqlserver.md
+useLegacyBuild: true

--- a/mongodb/meta.yaml
+++ b/mongodb/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/mongodb/img/integrations_mongodb%402x.png
 logo_small: /images/repos/mongodb/img/integrations_mongodb.png
 project_url: https://github.com/signalfx/mongodb
+useLegacyBuild: true

--- a/mysql/meta.yaml
+++ b/mysql/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/mysql/img/integrations_mysql%402x.png
 logo_small: /images/repos/mysql/img/integrations_mysql.png
 project_url: https://github.com/signalfx/integrations/tree/master/mysql
+useLegacyBuild: true

--- a/newrelic/meta.yaml
+++ b/newrelic/meta.yaml
@@ -7,3 +7,4 @@ display_name: New Relic
 featured: false
 logo_large: /images/repos/newrelic/img/integrations_newrelic.png
 logo_small: /images/repos/newrelic/img/integrations_newrelic.png
+useLegacyBuild: true

--- a/nginx/meta.yaml
+++ b/nginx/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/nginx/img/integrations_nginx%402x.png
 logo_small: /images/repos/nginx/img/integrations_nginx.png
 project_url: https://github.com/signalfx/integrations/tree/master/nginx
+useLegacyBuild: true

--- a/openstack/meta.yaml
+++ b/openstack/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/openstack/img/integration_openstack%402x.png
 logo_small: /images/repos/openstack/img/integration_openstack.png
 project_url: https://github.com/signalfx/integrations/tree/master/openstack
+useLegacyBuild: true

--- a/pops/meta.yaml
+++ b/pops/meta.yaml
@@ -4,3 +4,4 @@ description: Aggregate metrics with different tokens from collectd, json, or pro
 display_name: SignalFx POPS (Point Of Presence Service)
 featured: false
 project_url: https://github.com/signalfx/integrations/tree/master/pops
+useLegacyBuild: true

--- a/postgresql/meta.yaml
+++ b/postgresql/meta.yaml
@@ -9,3 +9,4 @@ in_app_categories:
 logo_large: /images/repos/postgresql/img/integrations_postgresql%402x.png
 logo_small: /images/repos/postgresql/img/integrations_postgresql.png
 project_url: https://github.com/signalfx/integrations/tree/master/postgresql
+useLegacyBuild: true

--- a/rabbitmq/meta.yaml
+++ b/rabbitmq/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/rabbitmq/img/integrations_rabbitmq%402x.png
 logo_small: /images/repos/rabbitmq/img/integrations_rabbitmq.png
 project_url: https://github.com/signalfx/integrations/tree/master/rabbitmq
+useLegacyBuild: true

--- a/redis/meta.yaml
+++ b/redis/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/redis/img/integrations_redis%402x.png
 logo_small: /images/repos/redis/img/integrations_redis.png
 project_url: https://github.com/signalfx/integrations/tree/master/redis
+useLegacyBuild: true

--- a/signalfx-agent/meta.yaml
+++ b/signalfx-agent/meta.yaml
@@ -11,3 +11,4 @@ logo_large: /images/repos/collectd/img/integration_smartagent@2x.png
 logo_small: /images/repos/collectd/img/integration_smartagent.png
 project_url: https://github.com/signalfx/signalfx-agent
 sort_order: 0
+useLegacyBuild: true

--- a/signalfx-metadata/meta.yaml
+++ b/signalfx-metadata/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/collectd-signalfx/img/integrations_signalfx-collectd-plugin%402x.png
 logo_small: /images/repos/collectd-signalfx/img/integrations_signalfx-collectd-plugin.png
 project_url: https://github.com/signalfx/integrations/tree/master/collectd-signalfx
+useLegacyBuild: true

--- a/signalfx-org-metrics/meta.yaml
+++ b/signalfx-org-metrics/meta.yaml
@@ -1,3 +1,4 @@
 description: SignalFx generates a number of metrics you can use to monitor the status
   of your organization.
 display_name: Organization-level metrics sent by SignalFx
+useLegacyBuild: true

--- a/signalfx-smart-gateway/meta.yaml
+++ b/signalfx-smart-gateway/meta.yaml
@@ -9,3 +9,4 @@ logo_large: integration_smartgateway@2x.png
 logo_small: integration_smartgateway.png
 project_url: https://docs.signalfx.com/en/latest/apm/apm-overview/index.html
 sort_order: 0
+useLegacyBuild: true

--- a/solr/meta.yaml
+++ b/solr/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/solr/img/integrations_solr%402x.png
 logo_small: /images/repos/solr/img/integrations_solr.png
 project_url: https://github.com/signalfx/integrations/tree/master/solr
+useLegacyBuild: true

--- a/spark/meta.yaml
+++ b/spark/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: /images/repos/spark/img/integrations_apachespark%402x.png
 logo_small: /images/repos/spark/img/integrations_apachespark.png
 project_url: https://github.com/signalfx/integrations/tree/master/spark
+useLegacyBuild: true

--- a/splunk/meta.yaml
+++ b/splunk/meta.yaml
@@ -10,3 +10,4 @@ in_app_categories:
 logo_large: integration_splunk@2x.png
 logo_small: integration_splunk.png
 project_url: https://github.com/signalfx/integrations/tree/master/splunk
+useLegacyBuild: true

--- a/statsd/meta.yaml
+++ b/statsd/meta.yaml
@@ -9,3 +9,4 @@ in_app_categories:
 logo_large: /images/repos/statsd/img/integrations_statsd%402x.png
 logo_small: /images/repos/statsd/img/integrations_statsd.png
 project_url: https://github.com/signalfx/integrations/tree/master/statsd
+useLegacyBuild: true

--- a/telegraf/meta.yaml
+++ b/telegraf/meta.yaml
@@ -9,3 +9,4 @@ in_app_categories:
 logo_large: /images/repos/telegraf/img/integrations_telegraf%402x.png
 logo_small: /images/repos/telegraf/img/integrations_telegraf.png
 project_url: https://github.com/signalfx/integrations/tree/master/telegraf
+useLegacyBuild: true

--- a/traefik/meta.yaml
+++ b/traefik/meta.yaml
@@ -9,3 +9,4 @@ in_app_categories:
 logo_large: /images/repos/signalfx-agent-traefik/img/integration_traefik%402x.png
 logo_small: /images/repos/signalfx-agent-traefik/img/integration_traefik.png
 project_url: https://github.com/signalfx/integrations/tree/master/traefik
+useLegacyBuild: true

--- a/vsphere/meta.yaml
+++ b/vsphere/meta.yaml
@@ -8,3 +8,4 @@ in_app_categories:
 - servicesMonitored
 logo_large: /images/repos/vsphere/img/vsphere-logo2x.png
 logo_small: /images/repos/vsphere/img/vsphere-logo.png
+useLegacyBuild: true

--- a/win-metrics.net/meta.yaml
+++ b/win-metrics.net/meta.yaml
@@ -5,3 +5,4 @@ featured: false
 logo_large: /images/repos/win-metrics.net/img/integrations_windows%402x.png
 logo_small: /images/repos/win-metrics.net/img/integrations_windows.png
 project_url: https://github.com/signalfx/integrations/tree/master/win-metrics.net
+useLegacyBuild: true

--- a/win-perfcounter/meta.yaml
+++ b/win-perfcounter/meta.yaml
@@ -6,3 +6,4 @@ featured: false
 logo_large: /images/repos/win-perfcounter/img/integrations_windows%402x.png
 logo_small: /images/repos/win-perfcounter/img/integrations_windows.png
 project_url: https://github.com/signalfx/integrations/tree/master/win-perfcounter
+useLegacyBuild: true

--- a/win-statsd.net/meta.yaml
+++ b/win-statsd.net/meta.yaml
@@ -7,3 +7,4 @@ in_app_categories:
 logo_large: /images/repos/win-statsd.net/img/integrations_windows%402x.png
 logo_small: /images/repos/win-statsd.net/img/integrations_windows.png
 project_url: https://github.com/signalfx/integrations/tree/master/win-statsd.net
+useLegacyBuild: true

--- a/zookeeper/meta.yaml
+++ b/zookeeper/meta.yaml
@@ -9,3 +9,4 @@ in_app_categories:
 logo_large: /images/repos/zookeeper/img/integrations_zookeeper%402x.png
 logo_small: /images/repos/zookeeper/img/integrations_zookeeper.png
 project_url: https://github.com/signalfx/integrations/tree/master/zookeeper
+useLegacyBuild: true


### PR DESCRIPTION
This is in preparation for a signalview change that will allow
toggling between the old and new build process.