### PR TITLE
DOCS-1494: remove whitelist/blacklist terminology from docs

### DIFF
--- a/activemq/SMART_AGENT_MONITOR.md
+++ b/activemq/SMART_AGENT_MONITOR.md
@@ -169,12 +169,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/apache/SMART_AGENT_MONITOR.md
+++ b/apache/SMART_AGENT_MONITOR.md
@@ -158,12 +158,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/cassandra/SMART_AGENT_MONITOR.md
+++ b/cassandra/SMART_AGENT_MONITOR.md
@@ -242,12 +242,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/collectd-cpu/SMART_AGENT_MONITOR.md
+++ b/collectd-cpu/SMART_AGENT_MONITOR.md
@@ -92,12 +92,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/consul/SMART_AGENT_MONITOR.md
+++ b/consul/SMART_AGENT_MONITOR.md
@@ -167,12 +167,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/couchbase/SMART_AGENT_MONITOR.md
+++ b/couchbase/SMART_AGENT_MONITOR.md
@@ -375,12 +375,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/docker/SMART_AGENT_MONITOR.md
+++ b/docker/SMART_AGENT_MONITOR.md
@@ -208,12 +208,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/elasticsearch/SMART_AGENT_MONITOR.md
+++ b/elasticsearch/SMART_AGENT_MONITOR.md
@@ -504,12 +504,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/etcd/SMART_AGENT_MONITOR.md
+++ b/etcd/SMART_AGENT_MONITOR.md
@@ -107,12 +107,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/gitlab/SMART_AGENT_MONITOR.md
+++ b/gitlab/SMART_AGENT_MONITOR.md
@@ -271,12 +271,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/hadoop/SMART_AGENT_MONITOR.md
+++ b/hadoop/SMART_AGENT_MONITOR.md
@@ -317,12 +317,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/haproxy/SMART_AGENT_MONITOR.md
+++ b/haproxy/SMART_AGENT_MONITOR.md
@@ -211,12 +211,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/java/SMART_AGENT_MONITOR.md
+++ b/java/SMART_AGENT_MONITOR.md
@@ -210,12 +210,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/jenkins/SMART_AGENT_MONITOR.md
+++ b/jenkins/SMART_AGENT_MONITOR.md
@@ -146,12 +146,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/kafka/SMART_AGENT_MONITOR.md
+++ b/kafka/SMART_AGENT_MONITOR.md
@@ -157,12 +157,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/kong/SMART_AGENT_MONITOR.md
+++ b/kong/SMART_AGENT_MONITOR.md
@@ -83,7 +83,7 @@ monitors:
         report: false
 ```
 
-Sample YAML configuration with custom /signalfx route and white and blacklists
+Sample YAML configuration with custom /signalfx route and filter lists
 
 ```yaml
 monitors:

--- a/kong/SMART_AGENT_MONITOR.md
+++ b/kong/SMART_AGENT_MONITOR.md
@@ -211,12 +211,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/logstash/SMART_AGENT_MONITOR.md
+++ b/logstash/SMART_AGENT_MONITOR.md
@@ -301,12 +301,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/memcached/SMART_AGENT_MONITOR.md
+++ b/memcached/SMART_AGENT_MONITOR.md
@@ -107,12 +107,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/mongodb-atlas/SMART_AGENT_MONITOR.md
+++ b/mongodb-atlas/SMART_AGENT_MONITOR.md
@@ -193,12 +193,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/mongodb/SMART_AGENT_MONITOR.md
+++ b/mongodb/SMART_AGENT_MONITOR.md
@@ -197,12 +197,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/mysql/SMART_AGENT_MONITOR.md
+++ b/mysql/SMART_AGENT_MONITOR.md
@@ -304,12 +304,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/nginx/SMART_AGENT_MONITOR.md
+++ b/nginx/SMART_AGENT_MONITOR.md
@@ -95,12 +95,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/openstack/SMART_AGENT_MONITOR.md
+++ b/openstack/SMART_AGENT_MONITOR.md
@@ -172,12 +172,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/postgresql/SMART_AGENT_MONITOR.md
+++ b/postgresql/SMART_AGENT_MONITOR.md
@@ -154,12 +154,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/rabbitmq/SMART_AGENT_MONITOR.md
+++ b/rabbitmq/SMART_AGENT_MONITOR.md
@@ -228,12 +228,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/redis/SMART_AGENT_MONITOR.md
+++ b/redis/SMART_AGENT_MONITOR.md
@@ -178,12 +178,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/signalfx-agent/agent_docs/config-schema.md
+++ b/signalfx-agent/agent_docs/config-schema.md
@@ -61,7 +61,7 @@ if not set.
 | `logging` | no | [object (see below)](#logging) | Log configuration |
 | `collectd` | no | [object (see below)](#collectd) | Configuration of the managed collectd subprocess |
 | `enableBuiltInFiltering` | no | bool | This must be unset or explicitly set to true. In prior versions of the agent, there was a filtering mechanism that relied heavily on an external whitelist.json file to determine which metrics were sent by default.  This is all inherent to the agent now and the old style of filtering is no longer available. (**default:** `true`) |
-| `metricsToInclude` | no | [list of objects (see below)](#metricstoinclude) | A list of metric filters that will whitelist/include metrics.  These filters take priority over the filters specified in `metricsToExclude`. |
+| `metricsToInclude` | no | [list of objects (see below)](#metricstoinclude) | A list of metric filters that will include metrics.  These filters take priority over the filters specified in `metricsToExclude`. |
 | `metricsToExclude` | no | [list of objects (see below)](#metricstoexclude) | A list of metric filters |
 | `propertiesToExclude` | no | [list of objects (see below)](#propertiestoexclude) | A list of properties filters |
 | `internalStatusHost` | no | string | The host on which the internal status server will listen.  The internal status HTTP server serves internal metrics and diagnostic information about the agent and can be scraped by the `internal-metrics` monitor. Can be set to `0.0.0.0` if you want to monitor the agent from another host.  If you set this to blank/null, the internal status server will not be started.  See `internalStatusPort`. (**default:** `"localhost"`) |

--- a/signalfx-agent/agent_docs/filtering.md
+++ b/signalfx-agent/agent_docs/filtering.md
@@ -56,9 +56,9 @@ on the datapoint that will not affect matching.
 
 The negation of items in either `metricNames` or a `dimensions` map value list
 item will serve to override (and thus reinclude) only other already excluded
-items from that same list.  Thus, if you want to do "whitelisting" of metric
-names or dimension values.hi, you can provide a list like `[ '*',
-'!whitelisted1', '!whitelisted2' ]` to exclude everything but those two
+items from that same list.  Thus, if you want to filter metric
+names or dimension values, you can provide a list like `[ '*',
+'!allowlist1', '!allowlist2' ]` to exclude everything but those two
 metrics.  This, along with the regex and glob capabilities, is explained more
 in [Overridable Filters](#overridable-filters).
 
@@ -80,7 +80,7 @@ globbed (i.e. where `*` is a wildcard for zero or more characters, and `?` is
 a wildcard for a single character) or specified as a Go-compatible regular
 expression (the value must be surrounded by `/` to be considered a regex).
 
-Sometimes it is easier to whitelist the properties you want to allow through,
+Sometimes it is easier to filter the properties you want to allow through,
 and not allow any others.
 You can do this by prefixing any config value with `!`, which will negate the
 matching value. This can be applied to any of the config options.

--- a/signalfx-agent/agent_docs/legacy-filtering.md
+++ b/signalfx-agent/agent_docs/legacy-filtering.md
@@ -5,7 +5,7 @@ This page describes the old style of filtering and is deprecated and removed in
 agent version 5.0+. See [Filtering](filtering.md) for how to configure
 filtering in SignalFx Smart Agent 4.7.0+.
 
-## Old-style whitelist filtering
+## Old-style allow list filtering
 In the Smart Agent prior to version 4.7.0, custom metrics were filtered out of
 the agent by means of a `whitelist.json` file that was referenced under the
 `metricsToExclude` section of the standard distributed config file.  This
@@ -24,7 +24,7 @@ We recommend upgrading the agent to at least 4.7.0 and setting the
 `enableBuiltInFitlering: true` flag, as it is much easier to configure and
 understand than the old `metricsToExlude`/`metricsToInclude` mechanism.  The
 only reason to not set `enableBuiltInFiltering: true` is if you have extensive
-modifications to the whitelisted metrics (especially via `metricsToInclude`)
+modifications to the allowed metrics (especially via `metricsToInclude`)
 and you don't want to rewrite all of that using `extraMetrics` (the new
 built-in filtering will filter out metrics before they can be processed by
 `metricsToInclude`, so that config will have no effect if built-in filtering is
@@ -54,7 +54,7 @@ used in the monitor config.  This is very useful when trying to filter on a
 heavily overloaded dimension, such as the `plugin_instance` dimension that most
 collectd-based monitors emit.
 
-Sometimes it is easier to whitelist the metrics you want to allow through.
+Sometimes it is easier to filter the metrics you want to allow through.
 You can do this by setting the `negated` option to `true` on a filter item.
 This makes all metric name and dimension matching negated so that only
 datapoints with that name or dimension are allowed through.  You would also
@@ -112,7 +112,7 @@ Examples:
       negated: true
 
     # This will be automatically merged with the above filter to produce one
-    # whitelist filter on three metric names for elasticsearch
+    # Filter on three metric names for elasticsearch
     - metricNames:
       - elasticsearch.thread_pool.inactive
       monitorType: elasticsearch
@@ -152,4 +152,4 @@ For example:
        app: bigapp
 ```
 
-This can be useful for overridding the built-in whitelist for metrics.
+This can be useful for overridding the built-in allow list for metrics.

--- a/signalfx-agent/agent_docs/monitors/cadvisor.md
+++ b/signalfx-agent/agent_docs/monitors/cadvisor.md
@@ -22,7 +22,7 @@ If you are running containers with Docker, there is a fair amount of
 duplication with the `docker-container-stats` monitor in terms of the
 metrics sent (under distinct metric names) so you may want to consider not
 enabling the Docker monitor in a K8s environment, or else use filtering to
-whitelist only certain metrics.  Note that this will cause the built-in
+allow only certain metrics.  Note that this will cause the built-in
 Docker dashboards to be blank, but container metrics will be available on
 the Kubernetes dashboards instead.
 

--- a/signalfx-agent/agent_docs/monitors/collectd-docker.md
+++ b/signalfx-agent/agent_docs/monitors/collectd-docker.md
@@ -111,12 +111,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](../legacy-filtering.html#old-style-whitelist-filtering).**
+[Old-style allow list filtering](../legacy-filtering.html#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](../legacy-filtering.html#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/signalfx-agent/agent_docs/monitors/collectd-haproxy.md
+++ b/signalfx-agent/agent_docs/monitors/collectd-haproxy.md
@@ -205,12 +205,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](../legacy-filtering.html#old-style-whitelist-filtering).**
+[Old-style allow list filtering](../legacy-filtering.html#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](../legacy-filtering.html#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/signalfx-agent/agent_docs/monitors/collectd-kong.md
+++ b/signalfx-agent/agent_docs/monitors/collectd-kong.md
@@ -77,7 +77,7 @@ monitors:
         report: false
 ```
 
-Sample YAML configuration with custom /signalfx route and white and blacklists
+Sample YAML configuration with custom /signalfx route and filter lists
 
 ```yaml
 monitors:

--- a/signalfx-agent/agent_docs/monitors/gitlab-unicorn.md
+++ b/signalfx-agent/agent_docs/monitors/gitlab-unicorn.md
@@ -15,7 +15,7 @@ Monitor Type: `gitlab-unicorn` ([Source](https://github.com/signalfx/signalfx-ag
 This is a monitor for GitLab's Unicorn server.  The Unicorn server comes
 with a Prometheus exporter that runs by default on port 8080 at the path
 `/-/metrics`.  The IP address of the SignalFx Smart Agent container or
-host, **needs to be whitelisted** as described
+host, **needs to be allowed** as described
 [here](https://docs.gitlab.com/ee/administration/monitoring/ip_whitelist.html)
 in order for the agent to access the endpoint.
 

--- a/solr/SMART_AGENT_MONITOR.md
+++ b/solr/SMART_AGENT_MONITOR.md
@@ -143,12 +143,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/spark/SMART_AGENT_MONITOR.md
+++ b/spark/SMART_AGENT_MONITOR.md
@@ -194,12 +194,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/vsphere/SMART_AGENT_MONITOR.md
+++ b/vsphere/SMART_AGENT_MONITOR.md
@@ -362,12 +362,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 

--- a/zookeeper/SMART_AGENT_MONITOR.md
+++ b/zookeeper/SMART_AGENT_MONITOR.md
@@ -90,12 +90,12 @@ monitors` after configuring this monitor in a running agent instance.
 **The following information only applies to agent version older than 4.7.0. If
 you have a newer agent and have set `enableBuiltInFiltering: true` at the top
 level of your agent config, see the section above. See upgrade instructions in
-[Old-style whitelist filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-whitelist-filtering).**
+[Old-style allow list filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#old-style-allow-list-filtering).**
 
 If you have a reference to the `whitelist.json` in your agent's top-level
 `metricsToExclude` config option, and you want to emit metrics that are not in
-that whitelist, then you need to add an item to the top-level
-`metricsToInclude` config option to override that whitelist (see [Inclusion
+that allow list, then you need to add an item to the top-level
+`metricsToInclude` config option to override that allow list (see [Inclusion
 filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
 


### PR DESCRIPTION
- replace "whitelist" with "allow list" (noun) and "allow" (verb).
- replace "blacklist" with "deny list" (noun) and "deny" (verb).