### PR TITLE
Adding sf.org metric and event to docs for large detector job failure

### DIFF
--- a/signalfx-org-metrics/README.md.jinja
+++ b/signalfx-org-metrics/README.md.jinja
@@ -31,12 +31,12 @@ SignalFx admins can see some of these values in built-in charts on the Organizat
 
 Some metrics send both a total value and a ByToken value, such as `sf.org.numAddDatapointCalls` and `sf.org.numAddDatapointCallsByToken`.
 
-The sum of all the ByToken values may be less than the value of the counterpart (non-token-based) metric; this is because no per-token value is sent for data that SignalFx retrieves on your behalf via AWS CloudWatch, GCP StackDriver, AppDynamics, or New Relic, as data sent from those integrations is not associated with a token. For example, if you sum the values sent for `sf.org.numAddDatapointCallsByToken`, the value may be less than the value of `sf.org.numAddDatapointCalls`, because the latter includes data from the specified integrations while the former does not.
+The sum of all the ByToken values may be less than the value of the counterpart (non-token-based) metric; this is because no per-token value is sent for data that SignalFx retrieves on your behalf via AWS CloudWatch, GCP StackDriver, AppDynamics, or New Relic, because data sent from those integrations is not associated with a token. For example, if you sum the values sent for `sf.org.numAddDatapointCallsByToken`, the value may be less than the value of `sf.org.numAddDatapointCalls`, because the latter includes data from the specified integrations while the former does not.
 
 
 ### About "per metric type" metrics
 
-Some metrics send a value for each metric type (counter, cumulative counter or gauge), resulting in three MTS for these metrics. Each MTS is sent with a dimension named `category` with a value of `COUNTER`, `CUMULATIVE_COUNTER`, or `GAUGE`. Because you can have multiple MTS for these metrics, you would need to use the Sum analytics function to see the total value. 
+Some metrics send a value for each metric type (counter, cumulative counter or gauge), resulting in three MTS for these metrics. Each MTS is sent with a dimension named `category` with a value of `COUNTER`, `CUMULATIVE_COUNTER`, or `GAUGE`. Because you can have multiple MTS for these metrics, you would need to use the Sum analytics function to see the total value.
 
 For example, you might receive 3 MTS for `sf.org.numMetricTimeSeriesCreated`, one representing the number of MTS that are counters, another for the number of MTS that are cumulative counters, and a third for the number of MTS that are gauges. To find the total number of MTS created, you need to sum those values.
 

--- a/signalfx-org-metrics/README.md.jinja
+++ b/signalfx-org-metrics/README.md.jinja
@@ -42,6 +42,13 @@ For example, you might receive 3 MTS for `sf.org.numMetricTimeSeriesCreated`, on
 
 Also, you could filter by a single value of `category`, such as `GAUGE`, to see only the metrics of that type.
 
+### About the metric tracking stopped detectors
+
+The `sf.org.numDetectorsAborted` metric monitors the number of detectors that were stopped because they reached a resource limit (usually an MTS limit of 250K or higher). That condition also generates an `sf.org.abortedDetectors` event to record detailed context including the detector ID and reason it stopped with the value/limit of MTS or datapoints, whichever caused it to stop.
+
+For information about events, see [View Additional Data With Events](https://docs.signalfx.com/en/latest/detect-alert/events-intro.html).
+
+
 ## Metrics
 
 {{ macros.metric_list(metrics) }}

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -142,8 +142,8 @@ sf.org.num.detector:
   title: sf.org.num.detector
 
 sf.org.numDetectorsAborted:
-  brief: Number of detectors that were aborted
-  description: 'Number of detector jobs stopped because MTS load (250K+) conflicts with hard resource limits.
+  brief: Number of detectors that were stopped
+  description: 'Number of detector jobs stopped because they reached a resource limit (usually MTS limit).
 
     Dimension(s): `orgId`
 

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1,9 +1,3 @@
-sf.org.abortedDetectors:
-  brief: Detailed events for any aborted detectors
-  description: Contains the detectorID and reason for abort with the value/limit of MTS or datapoints, whichever caused the detector to stop.
-  metric_type: cumulative
-  title: sf.org.abortedDetectors
-
 sf.org.grossDatapointsReceived:
   brief: SignalFx internal metric
   description: While you may see this metric in your organization, it is for SignalFx

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1,3 +1,9 @@
+sf.org.abortedDetectors:
+  brief: Detailed events for any aborted detectors
+  description: Contains the detectorID and reason for abort with the value/limit of MTS or datapoints, whichever caused the detector to stop.
+  metric_type: cumulative
+  title: sf.org.abortedDetectors
+
 sf.org.grossDatapointsReceived:
   brief: SignalFx internal metric
   description: While you may see this metric in your organization, it is for SignalFx

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -141,6 +141,16 @@ sf.org.num.detector:
   metric_type: gauge
   title: sf.org.num.detector
 
+sf.org.numDetectorsAborted:
+  brief: Number of detectors that were aborted
+  description: 'Number of detector jobs stopped because MTS load (250K+) conflicts with hard resource limits.
+
+    Dimension(s): `orgId`
+
+    Data Resolution: 5 seconds'
+  metric_type: counter
+  title: sf.org.numDetectorsAborted
+
 sf.org.num.detectortemplate:
   brief: SignalFx internal metric
   description: While you may see this metric in your organization, it is for SignalFx
@@ -1048,4 +1058,3 @@ sf.org.ui.num.pagevisits:
     internal use only.
   metric_type: null
   title: sf.org.ui.num.pagevisits
-


### PR DESCRIPTION
Reviewers, **please confirm that metric type identification for sf.org.abortedDetectors is accurate**. File currently says this is a metric of cumulative type (rather than gauge or counter type). 

Pull request fulfills DOCS-1577 when merge is approved. Based on POR-3105.