### PR TITLE
Revisions for active mq message age tile

### DIFF
--- a/activemq/README.md
+++ b/activemq/README.md
@@ -1,6 +1,6 @@
 # ![](./img/integrations_activemq.png) ActiveMQ
 
-Metadata associated with SignalFx's integration with ActiveMQ can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/activemq">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/activemq-integration">here</a>.
+Metadata associated with the SignalFx integration with ActiveMQ can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/activemq">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/activemq-integration">here</a>.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)

--- a/amq-message-age/README.md
+++ b/amq-message-age/README.md
@@ -20,7 +20,7 @@ To monitor the general health of ActiveMQ, see [SignalFx's ActiveMQ integration]
 
 ##### Built-in dashboards
 
-These dashboards accompany [SignalFx's ActiveMQ integration](https://github.com/signalfx/integrations/tree/master/activemq)[](sfx_link:activemq)).
+These dashboards accompany [SignalFx's ActiveMQ integration](https://github.com/signalfx/integrations/tree/master/activemq)[](sfx_link:activemq).
 
 - **ActiveMQ Message Age**: Shows the average age of messages in ActiveMQ queues.
 

--- a/amq-message-age/README.md
+++ b/amq-message-age/README.md
@@ -36,7 +36,7 @@ These dashboards accompany [SignalFx's ActiveMQ integration](https://github.com/
 
 ### INSTALLATION
 
-1. Download SignalFx's ActiveMQ message age listener from <a target="_blank" href="https://github.com/signalfx/activemq-integration">https://github.com/signalfx/activemq-integration</a>.
+1. Download the SignalFx ActiveMQ message age listener from <a target="_blank" href="https://github.com/signalfx/activemq-integration">https://github.com/signalfx/activemq-integration</a>.
 
 2. Modify `/activemq-integration/amq-message-age/properties` to provide values that make sense for your environment, as described in [Configuration](#configuration), below.
 
@@ -50,11 +50,12 @@ These dashboards accompany [SignalFx's ActiveMQ integration](https://github.com/
 
 #### Configuring your endpoint
 
-Before we can send metrics to SignalFx, we need to make sure you are sending them to the correct SignalFx realm.
-To determine what realm you are in (YOUR_SIGNALFX_REALM), check your profile page in the SignalFx web application (click the avatar in the upper right and click My Profile).
-If you are not in the `us0` realm, you will need to set the `sfx_host` configuration option, as shown below.
-
-You will also need to set the `token` configuration option to your SignalFx organization access token (YOUR_SIGNALFX_API_TOKEN).
+Before you can send metrics to SignalFx, you need to make sure you are sending them to the correct SignalFx realm.
+To determine what realm you are in (YOUR_SIGNALFX_REALM), check your profile page in the SignalFx web application, as follows:
+1. Click the avatar in the upper right.
+2. Click My Profile.
+3. If you are not in the `us0` realm, you will need to set the `sfx_host` configuration option, as shown below.
+4. Set the `token` configuration option to your SignalFx organization access token (YOUR_SIGNALFX_API_TOKEN).
 For more information on authentication, see the API's [Authentication documentation](https://developers.signalfx.com/basics/authentication.html).
 
 #### Configuration options
@@ -77,13 +78,13 @@ In some versions of ActiveMQ, messages sometimes get “stuck” in the queue, a
 
 This tool provides visibility into "stuck" messages in ActiveMQ by inspecting each enqueued message, calculating the average and maximum age of messages per queue, and reporting those metrics to SignalFx using our <a target="_blank" href="https://github.com/signalfx/integrations/tree/master/lib-java">Java client library</a>.
 
-Our built-in dashboard for this data makes it immediately visible when messages have been waiting a long time to be delivered.
+The built-in dashboard for this data makes it immediately visible when messages have been waiting too long to be delivered.
 
 ![](./img/dashboard_activemq_messageage.png)
 
 *In this example, one queue has messages that are nearly 40 seconds old.*
 
-Using these metrics from inside each message queue, we can create intelligent detectors that alert when there’s a message stuck in the queue and unable to be delivered. For example, you can create a detector that fires when the oldest message in the queue has been getting older for at least 5 minutes. To build this, we use the analytics function “Rate of change”, which lets us know how quickly a metric is changing.
+Using these metrics from inside each message queue, we can create intelligent detectors that alert when there’s a message stuck in the queue and unable to be delivered. For example, you can create a detector that fires when the oldest message in the queue has been getting older for at least 5 minutes. To build this, use the analytics function “Rate of change”, which lets us know how quickly a metric is changing.
 
 ![](./img/detector_activemq_messageage.png)
 

--- a/amq-message-age/README.md.jinja
+++ b/amq-message-age/README.md.jinja
@@ -1,7 +1,7 @@
 # ![](./img/integrations_activemq.png) ActiveMQ Message Age Listener
 {% import "macros.jinja" as macros %}
 
-Metadata associated with the ActiveMQ message age listener can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/amq-message-age">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/activemq-integration">here</a>.
+Metadata associated with ActiveMQ Message Age can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/amq-message-age">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/activemq-integration">in the ActiveMQ Message Age</a> directory.
 
 - [Description](#description)
 - [Requirements and Dependencies](#requirements-and-dependencies)
@@ -13,13 +13,13 @@ Metadata associated with the ActiveMQ message age listener can be found <a targe
 
 ## OVERVIEW
 
-SignalFx uses ActiveMQ Message Age to measures the age of messages in ActiveMQ queues and publish the results to SignalFx.
+You can use ActiveMQ Message Age Listener to measure the age of messages in ActiveMQ queues and publish the results to SignalFx.
 
 ### DESCRIPTION
 
 ActiveMQ Message Age Listener actively inspects the messages that are waiting to be delivered in each queue, and therefore is especially useful for detecting messages that are "stuck" in ActiveMQ queues and unable to be delivered.
 
-To monitor the general health of ActiveMQ, see [SignalFx's ActiveMQ integration](https://github.com/signalfx/integrations/tree/master/activemq)[](sfx_link:activemq).
+To monitor the general health of ActiveMQ, see [the ActiveMQ integration for SignalFx](https://github.com/signalfx/integrations/tree/master/activemq)[](sfx_link:activemq).
 
 #### FEATURES
 
@@ -45,7 +45,7 @@ These dashboards accompany [SignalFx's ActiveMQ integration](https://github.com/
 
 To access this tool, perform the following steps:
 
-1. Download the SignalFx ActiveMQ message age listener from <a target="_blank" href="https://github.com/signalfx/activemq-integration">https://github.com/signalfx/activemq-integration</a>.
+1. Download the SignalFx ActiveMQ Message Age Listener from <a target="_blank" href="https://github.com/signalfx/activemq-integration">https://github.com/signalfx/activemq-integration</a>.
 
 2. Modify `/activemq-integration/amq-message-age/properties` to provide values that make sense for your environment, as described in [Configuration](#configuration), below.
 
@@ -62,7 +62,7 @@ To access this tool, perform the following steps:
 Before you can send metrics to SignalFx, you need to make sure you are sending them to the correct SignalFx realm.
 To determine what realm you are in (YOUR_SIGNALFX_REALM), check your profile page in the SignalFx web application, as follows:
 1. Click the avatar in the upper right.
-2. Click My Profile.
+2. Click **My Profile**.
 3. If you are not in the `us0` realm, you will need to set the `sfx_host` configuration option, as shown below.
 4. Set the `token` configuration option to your SignalFx organization access token (YOUR_SIGNALFX_API_TOKEN).
 For more information on authentication, see the API's [Authentication documentation](https://developers.signalfx.com/basics/authentication.html).

--- a/amq-message-age/README.md.jinja
+++ b/amq-message-age/README.md.jinja
@@ -13,7 +13,7 @@ Metadata associated with the ActiveMQ message age listener can be found <a targe
 
 ## OVERVIEW
 
-This tool measures the age of messages in ActiveMQ queues, and publishes the results to SignalFx.
+SignalFx uses ActiveMQ Message Age to measures the age of messages in ActiveMQ queues and publish the results to SignalFx.
 
 ### DESCRIPTION
 
@@ -42,6 +42,8 @@ These dashboards accompany [SignalFx's ActiveMQ integration](https://github.com/
 ## SETUP
 
 ### INSTALLATION
+
+To access this tool, perform the following steps:
 
 1. Download the SignalFx ActiveMQ message age listener from <a target="_blank" href="https://github.com/signalfx/activemq-integration">https://github.com/signalfx/activemq-integration</a>.
 

--- a/amq-message-age/README.md.jinja
+++ b/amq-message-age/README.md.jinja
@@ -1,4 +1,5 @@
 # ![](./img/integrations_activemq.png) ActiveMQ Message Age Listener
+{% import "macros.jinja" as macros %}
 
 Metadata associated with the ActiveMQ message age listener can be found <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/amq-message-age">here</a>. The relevant code for the plugin can be found <a target="_blank" href="https://github.com/signalfx/activemq-integration">here</a>.
 
@@ -10,9 +11,13 @@ Metadata associated with the ActiveMQ message age listener can be found <a targe
 - [Metrics](#metrics)
 - [License](#license)
 
+## OVERVIEW
+
+This tool measures the age of messages in ActiveMQ queues, and publishes the results to SignalFx.
+
 ### DESCRIPTION
 
-This tool measures the age of messages in ActiveMQ queues, and publishes the results to SignalFx. It actively inspects the messages that are waiting to be delivered in each queue, and therefore is especially useful for detecting messages that are "stuck" in ActiveMQ queues and unable to be delivered.
+ActiveMQ Message Age Listener actively inspects the messages that are waiting to be delivered in each queue, and therefore is especially useful for detecting messages that are "stuck" in ActiveMQ queues and unable to be delivered.
 
 To monitor the general health of ActiveMQ, see [SignalFx's ActiveMQ integration](https://github.com/signalfx/integrations/tree/master/activemq)[](sfx_link:activemq).
 
@@ -33,6 +38,8 @@ These dashboards accompany [SignalFx's ActiveMQ integration](https://github.com/
 | ActiveMQ  | 5.8.0 or later |
 | Java | 1.5 or later |
 | Maven | (match with Java version) |
+
+## SETUP
 
 ### INSTALLATION
 
@@ -72,7 +79,7 @@ Supply values for the following properties in the `/activemq-integration/amq-mes
 | host\_name | Name of this ActiveMQ host. This value appears in the dimension `host` in SignalFx. | ActiveMQ_Host1 |
 | broker\_name | Name of this ActiveMQ broker. This value appears in the dimension `broker` in SignalFx. | Broker1 |
 
-### USAGE
+## USAGE
 
 In some versions of ActiveMQ, messages sometimes get “stuck” in the queue, and message consumers won’t pick them up even if they have available capacity. This bug causes messages to never be delivered. Monitoring tools are typically unable to detect this condition due to a lack of visibility into the messages that never make it out of the queue.
 

--- a/amq-message-age/meta.yaml
+++ b/amq-message-age/meta.yaml
@@ -11,4 +11,4 @@ in_app_categories:
 logo_large: integrations_activemq%402x.png
 logo_small: integrations_activemq.png
 project_url: https://github.com/signalfx/integrations/tree/master/amq-message-age
-useLegacyBuild: true
+useLegacyBuild: false


### PR DESCRIPTION
Updated tile to use new jinja template and surface prescriptive guidance per DOCS-1435