### PR TITLE
Add config for using opentelemetry-collector helm chart

### DIFF
--- a/opentelemetry-collector/helm/README.md
+++ b/opentelemetry-collector/helm/README.md
@@ -1,19 +1,21 @@
-This directory contains values.yaml files that can be used with helm to install the [OpenTelemetry Collector helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/master/charts/opentelemetry-collector).
+This directory contains values.yaml files that can be used with Helm to install the [OpenTelemetry Collector helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/master/charts/opentelemetry-collector).
 
-It configures the OpenTelemetry collector in forwarding mode where it sends traces and metrics sent to it to SignalFx.
+The chart configures the OpenTelemetry collector in forwarding mode where it sends traces and metrics sent to it to SignalFx.
 
 1. Download [values.yaml](values.yaml) and [env.yaml](env.yaml).
 1. Edit `env.yaml` to contain your access token, realm, etc.
-1. Install helm chart, e.g.:
+1. Install Helm chart, for example:
 
 ```sh
 $ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 $ helm install my-opentelemetry-collector open-telemetry/opentelemetry-collector -f values.yaml -f env.yaml
 ```
 
-Note: env.yaml must come after values.yaml
+**Note:** env.yaml must come after values.yaml
 
-A Kubernetes service is created (the name depends on the helm install name, using the above instructions it's named `my-opentelemetry-collector`). Using this service you can send metrics and traces to the collector. The table below details which port accepts which protocol.
+Installing the Helm chart creates a Kubernetes service. The name of the service depends on Helm install name. For example, using the instructions above, the service is named my-opentelemetry-collector.
+
+You can use this service to send metrics and traces to the collector. The following table describes which ports accept which protocols.
 
 | Protocol | Port |
 |---|---|

--- a/opentelemetry-collector/helm/README.md
+++ b/opentelemetry-collector/helm/README.md
@@ -1,0 +1,25 @@
+This directory contains values.yaml files that can be used with helm to install the [OpenTelemetry Collector helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/master/charts/opentelemetry-collector).
+
+It configures the OpenTelemetry collector in forwarding mode where it sends traces and metrics sent to it to SignalFx.
+
+1. Download [values.yaml](values.yaml) and [env.yaml](env.yaml).
+1. Edit `env.yaml` to contain your access token, realm, etc.
+1. Install helm chart, e.g.:
+
+```sh
+$ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+$ helm install my-opentelemetry-collector open-telemetry/opentelemetry-collector -f values.yaml -f env.yaml
+```
+
+Note: env.yaml must come after values.yaml
+
+A Kubernetes service is created (the name depends on the helm install name, using the above instructions it's named `my-opentelemetry-collector`). Using this service you can send metrics and traces to the collector. The table below details which port accepts which protocol.
+
+| Protocol | Port |
+|---|---|
+| OTLP | 55680 |
+| Jaegar-Thrift | 14268 |
+| Jaeger-gRPC | 14250 |
+| Zipkin | 9411 |
+| SignalFx Metrics Protobuf | 9943 |
+| SAPM | 7276 |

--- a/opentelemetry-collector/helm/env.yaml
+++ b/opentelemetry-collector/helm/env.yaml
@@ -1,0 +1,12 @@
+image:
+  tag: <VERSION>
+
+standaloneCollector:
+  configOverride:
+    exporters:
+      signalfx:
+        realm: # us0, us1, etc.
+        access_token: <ACCESS_TOKEN>
+      sapm:
+        access_token: <ACCESS_TOKEN>
+        endpoint: https://ingest.<REALM>.signalfx.com/v2/trace

--- a/opentelemetry-collector/helm/values.yaml
+++ b/opentelemetry-collector/helm/values.yaml
@@ -1,0 +1,84 @@
+# This configures a single OpenTelemetry Collector in forwarding mode.
+
+# Search for REPLACE and set deployment-specific values. This could be done inside this file,
+# in a separate values file, or as --set parameters. See env.yaml for an example secondary
+# values file.
+
+# Full set of values that can be set are at:
+#    https://github.com/open-telemetry/opentelemetry-helm-charts/blob/master/charts/opentelemetry-collector/values.yaml
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  # REPLACE
+  tag: "<VERSION>"
+
+# OpenTelemetry Collector executable
+command:
+  name: otelcontribcol
+
+ports:
+  signalfx:
+    enabled: true
+    containerPort: 9943
+    servicePort: 9943
+    hostPort: 9943
+    protocol: TCP
+  sapm:
+    enabled: true
+    containerPort: 7276
+    servicePort: 7276
+    hostPort: 7276
+    protocol: TCP
+  zpages:
+    enabled: true
+    containerPort: 55679
+    servicePort: 55679
+    hostPort: 55679
+    protocol: TCP
+
+# Configuration for agent OpenTelemetry Collector daemonset, enabled by default
+agentCollector:
+  enabled: false
+
+# Configuration for standalone OpenTelemetry Collector deployment, disabled by default
+standaloneCollector:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 1
+      memory: 2Gi
+  # Configuration override that will be merged into the standalone collector default config
+  configOverride:
+    receivers:
+      sapm: {}
+      signalfx: {}
+    extensions:
+      zpages:
+        endpoint: ":55679"
+    exporters:
+      signalfx:
+        # REPLACE
+        realm: <REALM> # e.g. us0, us1, etc.
+        # REPLACE
+        access_token: <ACCESS TOKEN>
+      sapm:
+        # REPLACE
+        access_token: <ACCESS TOKEN>
+        # REPLACE
+        endpoint: https://ingest.<REALM>.signalfx.com/v2/trace
+    service:
+      extensions: [zpages, health_check]
+      pipelines:
+        traces:
+          receivers: [sapm, otlp, jaeger, zipkin]
+          exporters: [sapm]
+        metrics:
+          receivers: [signalfx, prometheus]
+          exporters: [signalfx]
+
+service:
+  type: ClusterIP
+  annotations: {}


### PR DESCRIPTION
This adds example config for using with
https://github.com/open-telemetry/opentelemetry-helm-charts/blob/master/charts/opentelemetry-collector

See README.md for usage.

The section https://docs.signalfx.com/en/latest/apm/apm-getting-started/apm-opentelemetry-collector.html#deploy-an-opentelemetry-collector-in-kubernetes should link here or be replaced with the content in README.md (or something better).