### PR TITLE
Update README.md

### DIFF
--- a/lib-java/README.md
+++ b/lib-java/README.md
@@ -7,9 +7,9 @@
 
 ### DESCRIPTION
 
-This <a target="_blank" href="https://github.com/signalfx/signalfx-java">repository</a> contains libraries for instrumenting Java applications and reporting metrics to SignalFx, using Codahale Metrics.
+This <a target="_blank" href="https://github.com/signalfx/signalfx-java">repository</a> contains libraries for instrumenting Java applications and reporting metrics to Splunk Infrastructure Monitoring, using Codahale Metrics.
 
-You can also use the module `signalfx-java` to send metrics directly to SignalFx using protocol buffers, without using Codahale or Yammer metrics.
+You can also use the module `signalfx-java` to send metrics directly to Splunk Infrastructure Monitoring using protocol buffers, without using Codahale or Yammer metrics.
 
 For more information regarding installation, usage, and examples see https://github.com/signalfx/signalfx-java
 

--- a/lib-java/README.md
+++ b/lib-java/README.md
@@ -7,7 +7,7 @@
 
 ### DESCRIPTION
 
-This <a target="_blank" href="https://github.com/signalfx/integrations/tree/release/lib-java">repository</a> contains libraries for instrumenting Java applications and reporting metrics to SignalFx, using Codahale Metrics.
+This <a target="_blank" href="https://github.com/signalfx/signalfx-java">repository</a> contains libraries for instrumenting Java applications and reporting metrics to SignalFx, using Codahale Metrics.
 
 You can also use the module `signalfx-java` to send metrics directly to SignalFx using protocol buffers, without using Codahale or Yammer metrics.
 


### PR DESCRIPTION
fixed original self-referential link so it now links to the repo instead of back to doc file it was embedded in