### PR TITLE
Added missing metric to list

### DIFF
--- a/signalfx-org-metrics/README.md.jinja
+++ b/signalfx-org-metrics/README.md.jinja
@@ -24,7 +24,7 @@ Your organization is not charged for these metrics, and they do not count agains
 
 ## USAGE
 
-Application admins can see some of these values in built-in charts on the Organization Overview page. And, like any other metrics, you can display them on charts you build to monitor your system health.
+Admins can see some of these values in built-in charts on the Organization Overview page. And, like any other metrics, you can display them on charts you build to monitor your system health.
 
 
 ### About ByToken metrics

--- a/signalfx-org-metrics/README.md.jinja
+++ b/signalfx-org-metrics/README.md.jinja
@@ -11,20 +11,20 @@
 
 ## DESCRIPTION
 
-SignalFx generates a number of metrics you can use to monitor your usage of SignalFx, including:
+Splunk Infrastructure Monitoring generates a number of metrics you can use to monitor your usage of the application, including:
 
--  Ingest-related metrics that characterize the volume and nature of data that you are sending to SignalFx, such as the number of datapoints that were sent or how many metric time series were created in response to the datapoints and dimensions sent.
+-  Ingest-related metrics that characterize the volume and nature of data that you are sending to Infrastructure Monitoring, such as the number of datapoints that were sent or how many metric time series were created in response to the datapoints and dimensions sent.
 
 -  Usage or engagement metrics, such as the number of dashboards or charts in the organization.
 
--  Metrics that tell you how SignalFx pulls data on your behalf from cloud services like Amazon Web Services or Google Cloud Platform, such as the number of calls to each GCP Stackdriver client method or how many of the calls to the AWS CloudWatch API are being throttled by AWS.
+-  Metrics that tell you how the application pulls data on your behalf from cloud services like Amazon Web Services or Google Cloud Platform, such as the number of calls to each GCP Stackdriver client method or how many of the calls to the AWS CloudWatch API are being throttled by AWS.
 
 Your organization is not charged for these metrics, and they do not count against any limits.
 
 
 ## USAGE
 
-SignalFx admins can see some of these values in built-in charts on the Organization Overview page. And, like any other metrics, you can display them on charts you build to monitor your system health.
+Application admins can see some of these values in built-in charts on the Organization Overview page. And, like any other metrics, you can display them on charts you build to monitor your system health.
 
 
 ### About ByToken metrics

--- a/signalfx-org-metrics/meta.yaml
+++ b/signalfx-org-metrics/meta.yaml
@@ -1,4 +1,4 @@
-description: Splunk Infrastructure  Monitoring generates a number of metrics you can use to monitor the status
+description: Splunk Infrastructure Monitoring generates a number of metrics you can use to monitor the status
   of your organization.
 display_name: Organization-level metrics sent by Infrastructure Monitoring
 product_docs_name: signalfx.organization.metrics

--- a/signalfx-org-metrics/meta.yaml
+++ b/signalfx-org-metrics/meta.yaml
@@ -1,5 +1,5 @@
-description: SignalFx generates a number of metrics you can use to monitor the status
+description: Splunk Infrastructure  Monitoring generates a number of metrics you can use to monitor the status
   of your organization.
-display_name: Organization-level metrics sent by SignalFx
+display_name: Organization-level metrics sent by Infrastructure Monitoring
 product_docs_name: signalfx.organization.metrics
 useLegacyBuild: false

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -479,15 +479,17 @@ sf.org.num.gcpStackdriverClientCallCountThrottles:
   metric_type: counter
   title: sf.org.num.gcpStackdriverClientCallCountThrottles
 
-sf.org.num.metric:
-  brief: Number of unique metrics across all MTS
-  description: 'Number of unique metrics across all MTS.
+sf.org.num.LimitedMetricTimeSeriesCreateCallsByCategoryType:
+  brief: Number of metric time series created that are over the limit for an MTS category
+  description: 'Number of metric time series created that are over the purchased
+    limit for that MTS category (such as Host, Container, Custom, Tracing and Bundled).
 
     Dimension(s): `orgId`
 
     Data Resolution: 15 minutes'
   metric_type: gauge
-  title: sf.org.num.metric
+  title: sf.org.num.LimitedMetricTimeSeriesCreateCallsByCategoryType
+
 
 sf.org.num.metrictimeseries:
   brief: Number of metric time series available to be visualized in charts and detectors

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -479,16 +479,16 @@ sf.org.num.gcpStackdriverClientCallCountThrottles:
   metric_type: counter
   title: sf.org.num.gcpStackdriverClientCallCountThrottles
 
-sf.org.num.LimitedMetricTimeSeriesCreateCallsByCategoryType:
+sf.org.num.LimitedMetricTimeSeriesCreateCalls:
   brief: Number of metric time series created that are over the limit for an MTS category
   description: 'Number of metric time series created that are over the purchased
     limit for that MTS category (such as Host, Container, Custom, Tracing and Bundled).
 
-    Dimension(s): `orgId`
+    Dimension(s): `orgId` and `categoryType`
 
     Data Resolution: 15 minutes'
   metric_type: gauge
-  title: sf.org.num.LimitedMetricTimeSeriesCreateCallsByCategoryType
+  title: sf.org.num.LimitedMetricTimeSeriesCreateCalls
 
 
 sf.org.num.metrictimeseries:


### PR DESCRIPTION
Added metric to listing and rebranded from SignalFx to Splunk Infrastructure Monitoring.