### PR TITLE
Remove duplicate headers from ecs and couchbase templates

### DIFF
--- a/aws-ecs/README.md.jinja
+++ b/aws-ecs/README.md.jinja
@@ -1,12 +1,8 @@
-# ![](./img/integrations_awsecs.png) Amazon EC2 Container Service (ECS)
-
 {% import "macros.jinja" as macros %}
 
 {% if target == "docs" -%}
 
-# ![](../../_images/images-integrations/integrations-reference/aws-ecs/integrations_awsecs.png) Amazon ECS
-
-# Amazon EC2 Container Service (ECS)
+# ![](../../_images/images-integrations/integrations-reference/aws-ecs/integration_awsecs.png) Amazon ECS
 
 - [Overview](#overview)
 - [Setup](#setup)

--- a/couchbase/README.md.jinja
+++ b/couchbase/README.md.jinja
@@ -1,10 +1,7 @@
-# ![](./img/integrations_couchbase.png) Couchbase
 {% import "macros.jinja" as macros %}
 
 {% if target == "docs" -%}
 # ![](../../_images/images-integrations/integrations-reference/couchbase/integrations_couchbase.png) Couchbase
-
-# Couchbase
 
 - [Overview](#overview)
 - [Setup](#setup)


### PR DESCRIPTION
@pohannigansfx this should help with the issues seen in product docs (having multiple entries in integrations reference ToC and broken image for ECS).