### PR TITLE
Update metrics.yaml

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1363,14 +1363,12 @@ sf.org.limit.containers:
 sf.org.limit.customMetricTimeSeries:
   brief: Maximum number of custom MTS you can create in your organization within a 1 hour time window
   description: |
-
-  Maximum number of custom MTS you can create in your organization in a 1 hour time window.
-  If you exceed this limit, Infrastructure Monitoring stops accepting datapoints for new custom MTS,
-  but keeps accepting datapoints for existing custom MTS. To see the overall number of custom metrics
-  you've define, use the metric `sf.org.numCustomMetrics`.
-
-  Custom MTS use a metric defined by you, rather than a metric defined by an integration. To learn more about custom
-  MTS, see the user documentation section
-  (About custom, bundled, and high-resolution metrics)[https://docs.signalfx.com/en/latest/admin-guide/usage.html#about-custom-bundled-and-high-resolution-metrics].
+    Maximum number of custom MTS you can create in your organization in a 1 hour time window.
+    If you exceed this limit, Infrastructure Monitoring stops accepting datapoints for new custom MTS,
+    but keeps accepting datapoints for existing custom MTS. To see the overall number of custom metrics
+    you've define, use the metric `sf.org.numCustomMetrics`.
+    Custom MTS use a metric defined by you, rather than a metric defined by an integration. To learn more about custom
+    MTS, see the user documentation section
+    (About custom, bundled, and high-resolution metrics)[https://docs.signalfx.com/en/latest/admin-guide/usage.html#about-custom-bundled-and-high-resolution-metrics].
   metric_type: gauge
   title: sf.org.limit.customMetricTimeSeries

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1366,7 +1366,7 @@ sf.org.limit.customMetricTimeSeries:
     Maximum number of custom MTS you can create in your organization in a 1 hour time window.
     If you exceed this limit, Infrastructure Monitoring stops accepting datapoints for new custom MTS,
     but keeps accepting datapoints for existing custom MTS. To see the overall number of custom metrics
-    you've define, use the metric `sf.org.numCustomMetrics`.
+    you've defined, use the metric `sf.org.numCustomMetrics`.
     Custom MTS use a metric defined by you, rather than a metric defined by an integration. To learn more about custom
     MTS, see the user documentation section
     (About custom, bundled, and high-resolution metrics)[https://docs.signalfx.com/en/latest/admin-guide/usage.html#about-custom-bundled-and-high-resolution-metrics].


### PR DESCRIPTION
Fix a bug I introduced in metrics.yaml.

The last metric description wasn't using a correct form of YAML multi-line text.