### PR TITLE
DOCS-3278: Fix sf.org.num.azureMonitorClientCallCount description

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -408,14 +408,12 @@ sf.org.num.awsServiceCallThrottles:
 sf.org.num.azureMonitorClientCallCount:
   brief: Number of calls made to the Azure Monitor API
   description: |
-    Total number of calls made to the Amazon API.
+    Total number of calls made to the Azure Monitor API.
 
         * Dimension(s):  `orgId`, `subscription_id`, `type` (`metric_data_sync` for metric
-          syncing and `metric_metadata_sync` for property syncing), `method` (the function
-          being performed, `getTimeseries` for listing metrics and `getMetricDefinition`
-          for listing out metric definitions)
+          syncing and `metric_metadata_sync` for property syncing)
         * Data resolution: 5 seconds
-  metric_type: gauge
+  metric_type: counter
   title: sf.org.num.azureMonitorClientCallCount
 
 sf.org.num.azureMonitorClientCallCountErrors:
@@ -424,9 +422,7 @@ sf.org.num.azureMonitorClientCallCountErrors:
     Number of calls to Azure Monitor API method that threw errors.
 
         * Dimension(s):  `orgId`, `subscription_id`, `type` (`metric_data_sync` for metric
-          syncing and `metric_metadata_sync` for property syncing), `method` (the function
-          being performed, `getTimeseries` for listing metrics and `getMetricDefinition`
-          for listing out metric definitions)
+          syncing and `metric_metadata_sync` for property syncing)
         * Data resolution: 1 second
   metric_type: counter
   title: sf.org.num.azureMonitorClientCallCountErrors
@@ -437,9 +433,7 @@ sf.org.num.azureMonitorClientCallCountThrottles:
     Number of calls to Azure Monitor method that were throttled.
 
         * Dimension(s):  `orgId`, `subscription_id`, `type` (`metric_data_sync` for metric
-          syncing and `metric_metadata_sync` for property syncing), `method` (the function
-          being performed, `getTimeseries` for listing metrics and `getMetricDefinition`
-          for listing out metric definitions)
+          syncing and `metric_metadata_sync` for property syncing)
         * Data resolution: 1 second
   metric_type: counter
   title: sf.org.num.azureMonitorClientCallCountThrottles
@@ -1429,9 +1423,9 @@ sf.org.limit.customMetricTimeSeries:
 sf.org.limit.detector:
   brief: Maximum number of detectors you can use for your organization
   description: |
-    Maximum number of detectors you can use for your organization. After you reach this limit, 
-    you can't create more new detectors. 
-    To monitor the number of detectors you create, 
+    Maximum number of detectors you can use for your organization. After you reach this limit,
+    you can't create more new detectors.
+    To monitor the number of detectors you create,
     use the metric `sf.org.num.detector`.
   metric_type: gauge
   title: sf.org.limit.detector
@@ -1461,160 +1455,158 @@ sf.org.log.numMessagesReceived:
   brief: The total number of log messages Splunk Log Observer accepts after filtering and throttling.
   description: |
    The total number of log messages Splunk Log Observer accepts after filtering and throttling.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessagesReceived
- 
+
 sf.org.log.numContentBytesReceived:
   brief: The volume of bytes Splunk Log Observer receives from ingesting logs off the wire after filtering and throttling. This content can be compressed.
   description: |
    The volume of bytes Splunk Log Observer receives from ingesting logs off the wire after filtering and throttling. This content can be compressed.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numContentBytesReceived
- 
+
 sf.org.log.grossMessagesReceived:
   brief: The total number of log messages Splunk Log Observer receives before filtering and throttling.
   description: |
    The total number of log messages Splunk Log Observer receives before filtering and throttling.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.grossMessagesReceived
- 
+
 sf.org.log.numMessageBytesReceived:
   brief: The number of bytes Splunk Log Observer receives from ingested logs after decompression, filtering, and throttling are complete.
   description: |
    The number of bytes Splunk Log Observer receives from ingested logs after decompression, filtering, and throttling are complete.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessageBytesReceived
- 
+
 sf.org.log.grossContentBytesReceived:
   brief: The volume of bytes Splunk Log Observer receives from ingesting logs off the wire before filtering and throttling. This content can be compressed.
   description: |
    The volume of bytes Splunk Log Observer receives from ingesting logs off the wire before filtering and throttling. This content can be compressed.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.grossContentBytesReceived
- 
+
 sf.org.log.numMessagesReceivedByToken:
   brief: The total number of log messages Splunk Log Observer accepts for a specific access token after filtering and throttling.
   description: |
    The total number of log messages Splunk Log Observer accepts for a specific access token after filtering and throttling.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessagesReceivedByToken
- 
+
 sf.org.log.numMessagesDroppedOversize:
   brief: The number of log messages Splunk Log Observer receives that are too large to process.
   description: |
    The number of log messages Splunk Log Observer receives that are too large to process.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessagesDroppedOversize
- 
+
 sf.org.log.numMessagesDroppedThrottle:
   brief: The number of log messages Splunk Log Observer drops after the allowed ingest volume is exceeded. Splunk Log Observer drops messages it receives after the ingestion volume is reached.
   description: |
    The number of log messages Splunk Log Observer drops after the allowed ingest volume is exceeded. Splunk Log Observer drops messages it receives after the ingestion volume is reached.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessagesDroppedThrottle
- 
+
 sf.org.log.grossMessageBytesReceived:
   brief: The number of bytes Splunk Log Observer receives from ingested logs after decompression but before filtering and throttling are complete.
   description: |
    The number of bytes Splunk Log Observer receives from ingested logs after decompression but before filtering and throttling are complete.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.grossMessageBytesReceived
- 
+
 sf.org.log.numMessagesDroppedOversizeByToken:
   brief: The number of log messages Splunk Log Observer receives that are too large to process for a specific access token.
   description: |
    The number of log messages Splunk Log Observer receives that are too large to process for a specific access token.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessagesDroppedOversizeByToken
- 
+
 sf.org.log.grossContentBytesReceivedByToken:
   brief: The volume of bytes Splunk Log Observer receives from ingesting logs off the wire for a specific access token after filtering and throttling. This content can be compressed.
   description: |
    The volume of bytes Splunk Log Observer receives from ingesting logs off the wire for a specific access token after filtering and throttling. This content can be compressed.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.grossContentBytesReceivedByToken
- 
+
 sf.org.log.numMessagesDroppedThrottleByToken:
   brief: The number of log messages Splunk Log Observer drops for a specific access token after the allowed ingest volume is exceeded. Splunk Log Observer drops messages it receives after the ingestion volume is reached.
   description: |
    The number of log messages Splunk Log Observer drops for a specific access token after the allowed ingest volume is exceeded. Splunk Log Observer drops messages it receives after the ingestion volume is reached.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessagesDroppedThrottleByToken
- 
+
 sf.org.log.grossMessageBytesReceivedByToken:
   brief: The number of bytes Splunk Log Observer receives for a specific access token from ingested logs after decompression but before filtering and throttling are complete.
   description: |
    The number of bytes received by Splunk Log Observer for a specific access token from ingested logs after decompression but before filtering and throttling are complete.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.grossMessageBytesReceivedByToken
- 
+
 sf.org.log.numMessageBytesReceivedByToken:
   brief: The number of bytes Splunk Log Observer receives for a specific access token from ingested logs after decompression, filtering, and throttling are complete.
   description: |
    The number of bytes Splunk Log Observer receives for a specific access token from ingested logs after decompression, filtering, and throttling are complete.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessageBytesReceivedByToken
- 
+
 sf.org.log.grossMessagesReceivedByToken:
   brief: The total number of log messages Splunk Log Observer receives for a specific access token before filtering and throttling.
   description: |
    The total number of log messages Splunk Log Observer receives for a specific access token before filtering and throttling.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.grossMessagesReceivedByToken
- 
+
 sf.org.log.numContentBytesReceivedByToken:
   brief: The volume of bytes Splunk Log Observer receives from ingesting logs off the wire for a specific access token after filtering and throttling. This content can be compressed.
   description: |
    The volume of bytes Splunk Log Observer receives from ingesting logs off the wire for a specific access token after filtering and throttling. This content can be compressed.
- 
+
        * Dimension(s): `orgId`
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numContentBytesReceivedByToken
-
-


### PR DESCRIPTION
Per feedback from Bartek Gola in https://signalfuse.atlassian.net/browse/DOCS-3278, update the following metrics:

- sf.org.num.azureMonitorClientCallCount
- sf.org.num.azureMonitorClientCallCountErrors
- sf.org.num.azureMonitorClientCallCountThrottles

Update as follows:

- Amazon API → Azure Monitor API

- please remove this part from description: method (the function   being performed, getTimeseries for listing metrics and getMetricDefinition for listing out metric definitions)

- correct metric type is counter (not gauge)