### PR TITLE
DOCS-3869: Add to list of reasons for throttling

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -849,8 +849,7 @@ sf.org.numDatapointsDroppedExceededQuota:
     Total number of new data points you sent to Infrastructure Monitoring but that Infrastructure Monitoring
     didn't accept, because your organization exceeded its subscription limit.
     To learn more about the process Infrastructure Monitoring uses for incoming data when you exceed subscription
-    limits, see [Monitor Splunk Infrastructure Monitoring billing and usage - DPM plans only]
-    (https://docs.splunk.com/Observability/admin/imm-billing-usage/dpm-usage.html#monitor-splunk-infrastructure-monitoring-billing-and-usage-dpm-plans-only).
+    limits, see [this FAQ](https://docs.signalfx.com/en/latest/_sidebars-and-includes/dpm-faq.html).
 
         * Dimension(s):  `orgId`
         * Data resolution: 1 second
@@ -865,8 +864,7 @@ sf.org.numDatapointsDroppedExceededQuotaByToken:
     but that Infrastructure Monitoring didn't accept, because your organization exceeded its subscription
     limit.
     To learn more about the process Infrastructure Monitoring uses for incoming data when you exceed subscription
-    limits, see [Monitor Splunk Infrastructure Monitoring billing and usage - DPM plans only]
-    (https://docs.splunk.com/Observability/admin/imm-billing-usage/dpm-usage.html#monitor-splunk-infrastructure-monitoring-billing-and-usage-dpm-plans-only).
+    limits, see [DPM Limits - FAQ](https://docs.signalfx.com/en/latest/_sidebars-and-includes/dpm-faq.html).
     The sum of all the values might be less than the value of `sf.org.numDatapointsDroppedExceededQuota`.
     To learn more, see [Metrics for values by token](#metrics-for-values-by-token).
 

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -849,7 +849,8 @@ sf.org.numDatapointsDroppedExceededQuota:
     Total number of new data points you sent to Infrastructure Monitoring but that Infrastructure Monitoring
     didn't accept, because your organization exceeded its subscription limit.
     To learn more about the process Infrastructure Monitoring uses for incoming data when you exceed subscription
-    limits, see [this FAQ](https://docs.signalfx.com/en/latest/_sidebars-and-includes/dpm-faq.html).
+    limits, see [Monitor Splunk Infrastructure Monitoring billing and usage - DPM plans only]
+    (https://docs.splunk.com/Observability/admin/imm-billing-usage/dpm-usage.html#monitor-splunk-infrastructure-monitoring-billing-and-usage-dpm-plans-only).
 
         * Dimension(s):  `orgId`
         * Data resolution: 1 second
@@ -864,7 +865,8 @@ sf.org.numDatapointsDroppedExceededQuotaByToken:
     but that Infrastructure Monitoring didn't accept, because your organization exceeded its subscription
     limit.
     To learn more about the process Infrastructure Monitoring uses for incoming data when you exceed subscription
-    limits, see [DPM Limits - FAQ](https://docs.signalfx.com/en/latest/_sidebars-and-includes/dpm-faq.html).
+    limits, see [Monitor Splunk Infrastructure Monitoring billing and usage - DPM plans only]
+    (https://docs.splunk.com/Observability/admin/imm-billing-usage/dpm-usage.html#monitor-splunk-infrastructure-monitoring-billing-and-usage-dpm-plans-only).
     The sum of all the values might be less than the value of `sf.org.numDatapointsDroppedExceededQuota`.
     To learn more, see [Metrics for values by token](#metrics-for-values-by-token).
 
@@ -1099,8 +1101,8 @@ sf.org.numLimitedMetricTimeSeriesCreateCalls:
   brief: Number of MTS not sent; over maximum allowed
   description: |
     One value per metric type, each representing the number of metric
-    time series (MTS) not sent to Infrastructure Monitoring because you've reached your maximum active
-    MTS allowed.
+    time series (MTS) not sent to Infrastructure Monitoring because you've reached your maximum limit for active
+    MTS, hosts, containers, custom metrics, or datapoints per minute (DPM).
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
@@ -1115,7 +1117,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCallsByToken:
   description: |
     One value per metric type per token, each representing the number
     of metric time series (MTS) not sent to Infrastructure Monitoring because you've reached your
-    maximum active MTS allowed.
+    maximum limit for active MTS, hosts, containers, custom metrics, or datapoints per minute (DPM).
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
@@ -1550,7 +1552,7 @@ sf.org.log.numMessagesDroppedOversizeByToken:
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessagesDroppedOversizeByToken
- 
+
 sf.org.log.grossContentBytesReceivedByToken:
   brief: The volume of bytes Splunk Log Observer receives from ingesting logs off the wire for a specific access token after filtering and throttling. This content can be compressed.
   description: |

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1100,7 +1100,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCalls:
   description: |
     One value per metric type, each representing the number of metric
     time series (MTS) not sent to Infrastructure Monitoring because you've reached your maximum limit for active
-    MTS, hosts, containers, custom metrics, bundled metrics, functions, or high-resolution metrics.
+    MTS, hosts, containers, custom metrics, bundled metrics, functions, high-resolution metrics, Application Performance Monitoring (APM) metrics, or APM bundled metrics.
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
@@ -1115,7 +1115,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCallsByToken:
   description: |
     One value per metric type per token, each representing the number
     of metric time series (MTS) not sent to Infrastructure Monitoring because you've reached your
-    maximum limit for active MTS, hosts, containers, custom metrics, bundled metrics, functions, or high-resolution metrics.
+    maximum limit for active MTS, hosts, containers, custom metrics, bundled metrics, functions, high-resolution metrics, Application Performance Monitoring (APM) metrics, or APM bundled metrics.
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1100,7 +1100,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCalls:
   description: |
     One value per metric type, each representing the number of metric
     time series (MTS) not sent to Infrastructure Monitoring because you've reached your maximum limit for active
-    MTS, hosts, containers, custom metrics, or datapoints per minute (DPM).
+    MTS, hosts, containers, custom metrics, bundled metrics, functions, or high-resolution metrics.
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
@@ -1115,7 +1115,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCallsByToken:
   description: |
     One value per metric type per token, each representing the number
     of metric time series (MTS) not sent to Infrastructure Monitoring because you've reached your
-    maximum limit for active MTS, hosts, containers, custom metrics, or datapoints per minute (DPM).
+    maximum limit for active MTS, hosts, containers, custom metrics, bundled metrics, functions, or high-resolution metrics.
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1100,7 +1100,8 @@ sf.org.numLimitedMetricTimeSeriesCreateCalls:
   description: |
     One value per metric type, each representing the number of metric
     time series (MTS) not sent to Infrastructure Monitoring because you've reached your maximum limit for active
-    MTS, hosts, containers, custom metrics, bundled metrics, functions, high-resolution metrics, Application Performance Monitoring (APM) metrics, or APM bundled metrics.
+    MTS, hosts, containers, custom metrics, bundled metrics, functions, high-resolution metrics, 
+    Application Performance Monitoring (APM) metrics, or APM bundled metrics.
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
@@ -1115,7 +1116,8 @@ sf.org.numLimitedMetricTimeSeriesCreateCallsByToken:
   description: |
     One value per metric type per token, each representing the number
     of metric time series (MTS) not sent to Infrastructure Monitoring because you've reached your
-    maximum limit for active MTS, hosts, containers, custom metrics, bundled metrics, functions, high-resolution metrics, Application Performance Monitoring (APM) metrics, or APM bundled metrics.
+    maximum limit for active MTS, hosts, containers, custom metrics, bundled metrics, functions, high-resolution metrics, 
+    Application Performance Monitoring (APM) metrics, or APM bundled metrics.
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).


### PR DESCRIPTION
Update docs per this feedback:

> The documentation on [this page](https://docs.splunk.com/Observability/admin/org-metrics.html) is incorrect for `sf.org.numLimitedMetricTimeSeriesCreateCalls` and `sf.org.numLimitedMetricTimeSeriesCreateCallsByToken`
> 
> My understanding is that this metric reflects the MTS dropped due to violating a host, container, custom metric, DPM, or AMTS limit (not just active MTS limit, that’s misleading)