### PR TITLE
Revert "DOCS-3869: Add to list of reasons for throttling (#958)"

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1099,9 +1099,8 @@ sf.org.numLimitedMetricTimeSeriesCreateCalls:
   brief: Number of MTS not sent; over maximum allowed
   description: |
     One value per metric type, each representing the number of metric
-    time series (MTS) not sent to Infrastructure Monitoring because you've reached your maximum limit for active
-    MTS, hosts, containers, custom metrics, bundled metrics, functions, high-resolution metrics, 
-    Application Performance Monitoring (APM) metrics, or APM bundled metrics.
+    time series (MTS) not sent to Infrastructure Monitoring because you've reached your maximum active
+    MTS allowed.
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
@@ -1116,8 +1115,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCallsByToken:
   description: |
     One value per metric type per token, each representing the number
     of metric time series (MTS) not sent to Infrastructure Monitoring because you've reached your
-    maximum limit for active MTS, hosts, containers, custom metrics, bundled metrics, functions, high-resolution metrics, 
-    Application Performance Monitoring (APM) metrics, or APM bundled metrics.
+    maximum active MTS allowed.
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
@@ -1552,7 +1550,7 @@ sf.org.log.numMessagesDroppedOversizeByToken:
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numMessagesDroppedOversizeByToken
-
+ 
 sf.org.log.grossContentBytesReceivedByToken:
   brief: The volume of bytes Splunk Log Observer receives from ingesting logs off the wire for a specific access token after filtering and throttling. This content can be compressed.
   description: |


### PR DESCRIPTION
Reverts signalfx/integrations#959 - broke HTML on doc site