### PR TITLE
pin MarkupSafe version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+MarkupSafe==2.0.1
 Jinja2==2.11.3
 PyYAML==5.4


### PR DESCRIPTION
Jinja uses >=0.23 but MarkupSafe 2.1.0 made a breaking change