### PR TITLE
DOCS-3971 Switch descriptions for metrics

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1130,7 +1130,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCalls:
   title: sf.org.numLimitedMetricTimeSeriesCreateCalls
 
 sf.org.numLimitedMetricTimeSeriesCreateCallsByCategoryType:
-  brief: Number of MTS not sent; over maximum allowed
+  brief: Number of MTS not sent; over maximum allowed.
   description: |
     One value per metric type, each representing the number of metric
     time series (MTS) not sent to Infrastructure Monitoring because you've reached your maximum limit for active

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1120,6 +1120,16 @@ sf.org.numLimitedEventTimeSeriesCreateCallsByToken:
   title: sf.org.numLimitedEventTimeSeriesCreateCallsByToken
 
 sf.org.numLimitedMetricTimeSeriesCreateCalls:
+  brief: Number of MTS not created because your account reached a category limit (or subscription limit).
+  description: |
+    Number of metric time series (MTS) not created because your account reached a category limit (or subscription limit).
+
+        * Dimension(s):  `category`, `orgId`
+        * Data resolution: 1 second
+  metric_type: counter
+  title: sf.org.numLimitedMetricTimeSeriesCreateCalls
+
+sf.org.numLimitedMetricTimeSeriesCreateCallsByCategoryType:
   brief: Number of MTS not sent; over maximum allowed
   description: |
     One value per metric type, each representing the number of metric
@@ -1129,16 +1139,6 @@ sf.org.numLimitedMetricTimeSeriesCreateCalls:
     You can have up to three MTS for this metric; each MTS is sent with a dimension
     named `category` with a value of "counter", "cumulative_counter", or "gauge". To
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
-
-        * Dimension(s):  `category`, `orgId`
-        * Data resolution: 1 second
-  metric_type: counter
-  title: sf.org.numLimitedMetricTimeSeriesCreateCalls
-
-sf.org.numLimitedMetricTimeSeriesCreateCallsByCategoryType:
-  brief: Number of MTS not created because your account reached a category limit (or subscription limit).
-  description: |
-    Number of metric time series (MTS) not created because your account reached a category limit (or subscription limit).
 
         * Dimension(s):  `categoryType`, `orgId`
         * Data resolution: 35 seconds

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1125,7 +1125,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCalls:
     Number of metric time series (MTS) not created because your account reached a category limit (or subscription limit).
 
         * Dimension(s):  `category`, `orgId`
-        * Data resolution: 1 second
+        * Data resolution: 10 seconds
   metric_type: counter
   title: sf.org.numLimitedMetricTimeSeriesCreateCalls
 
@@ -1141,7 +1141,7 @@ sf.org.numLimitedMetricTimeSeriesCreateCallsByCategoryType:
     learn more, see [Metrics with values for each metric type](#metrics-with-values-for-each-metric-type).
 
         * Dimension(s):  `categoryType`, `orgId`
-        * Data resolution: 35 seconds
+        * Data resolution: 10 seconds
   metric_type: counter
   title: sf.org.numLimitedMetricTimeSeriesCreateCallsByCategoryType
 


### PR DESCRIPTION
Doc feedback given in this JIRA ticket: https://signalfuse.atlassian.net/browse/DOCS-3971

Summary: switched the descriptions and briefs for the two metrics sf.org.numLimitedMetricTimeSeriesCreateCalls and sf.org.numLimitedMetricTimeSeriesCreateCallsByCategoryType. 