### PR TITLE
DOCS-2113: Add new subscription metrics (fix)

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1662,3 +1662,39 @@ sf.org.log.numContentBytesReceivedByToken:
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numContentBytesReceivedByToken
+
+sf.org.subscription.containers:
+  brief: Number of containers.
+  description: |
+    Number of containers.
+    
+    * Data resolution: 10 seconds
+  metric_type: gauge
+  title: sf.org.subscription.containers
+
+sf.org.subscription.customMetrics:
+  brief: Number of custom metric time series.
+  description: |
+    Number of custom metric time series.
+    
+    * Data resolution: 10 seconds
+  metric_type: gauge
+  title: sf.org.subscription.customMetrics
+
+sf.org.subscription.highResolutionMetrics:
+  brief: Number of high resolution metric time series.
+  description: |
+    Number of high resolution metric time series.
+      
+    * Data resolution: 10 seconds
+  metric_type: gauge
+  title: sf.org.subscription.highResolutionMetrics
+ 
+sf.org.subscription.hosts:
+  brief: Number of hosts.
+  description: |
+    Number of hosts.
+    
+      * Data resolution: 10 seconds
+  metric_type: gauge
+  title: sf.org.subscription.hosts


### PR DESCRIPTION
Original PR experienced a parsing error and we had to revert the changes. This PR is a fix for the previous one. 