### PR TITLE
DOCS-1552: Update documentation of IMM Metrics

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1291,10 +1291,13 @@ sf.org.numPropertyLimitedMetricTimeSeriesCreateCallsByToken:
   title: sf.org.numPropertyLimitedMetricTimeSeriesCreateCallsByToken
 
 sf.org.numResourceMetrics:
-  brief: Number of resource metric time series (MTS).
+  brief: Number of resource metric time series (MTS) monitored.
   description: |
     Number of resource metric time series (MTS) received from host and container 
-    categories. 
+    categories. Resource MTS measure the use of limited subscription resources, such as 
+    custom MTS. 
+    
+    The `resourceType` dimension indicates whether the value represents hosts or containers.
     
     * Dimension(s): `orgId`, `resourceType`
     * Data resolution: 10 minutes
@@ -1713,7 +1716,7 @@ sf.org.subscription.hosts:
 sf.org.subscription.function:
   brief: Number of functions.
   description: |
-    Number of serverless functions included in the subscription.
+    Number of AWS Lambda functions included in the subscription.
     
     * Data resolution: 2 minutes
   metric_type: gauge

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1662,3 +1662,39 @@ sf.org.log.numContentBytesReceivedByToken:
        * Data resolution: 10 second
   metric_type: counter
   title: sf.org.log.numContentBytesReceivedByToken
+
+sf.org.subscription.containers:
+  brief: Number of containers.
+  description: |
+    Number of containers.
+    
+    * Data resolution: 10 seconds
+  metric_type: gauge
+  title: sf.org.subscription.containers
+
+sf.org.subscription.customMetrics:
+  brief: Number of custom metric time series.
+  description: |
+    Number of custom metric time series.
+    
+    * Data resolution: 10 seconds
+  metric_type: gauge
+  title: sf.org.subscription.customMetrics
+
+sf.org.subscription.highResolutionMetrics:
+  brief: Number of high resolution metric time series.
+  description: |
+    Number of high resolution metric time series.
+      
+    * Data resolution: 10 seconds
+  metric_type: gauge
+  title: sf.org.subscription.highResolutionMetrics
+ 
+sf.org.subscription.hosts:
+  brief: Number of hosts.
+  description: |
+    Number of hosts.
+    
+      * Data resolution: 10 seconds
+  metric_type: gauge
+  title: sf.org.subscription.hosts

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1294,8 +1294,7 @@ sf.org.numResourceMetrics:
   brief: Number of resource metric time series (MTS) monitored.
   description: |
     Number of resource metric time series (MTS) received from host and container 
-    categories. Resource MTS measure the use of limited subscription resources, such as 
-    custom MTS. 
+    categories. 
     
     The `resourceType` dimension indicates whether the value represents hosts or containers.
     
@@ -1716,7 +1715,7 @@ sf.org.subscription.hosts:
 sf.org.subscription.function:
   brief: Number of functions.
   description: |
-    Number of AWS Lambda functions included in the subscription.
+    Number of serverless functions included in the subscription.
     
     * Data resolution: 2 minutes
   metric_type: gauge

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1290,6 +1290,16 @@ sf.org.numPropertyLimitedMetricTimeSeriesCreateCallsByToken:
   metric_type: counter
   title: sf.org.numPropertyLimitedMetricTimeSeriesCreateCallsByToken
 
+sf.org.numResourceMetrics:
+  brief: Number of host-based resource metric time series.
+  description: |
+    Number of host-based resource metric time series.
+    
+    * Dimension(s): `orgId`, `resourceType`
+    * Data resolution: 10 minutes
+  metric_type: gauge
+  title: sf.org.numResourceMetrics
+
 sf.org.numResourcesMonitored:
   brief: Number of host-based resources monitored
   description: |
@@ -1698,3 +1708,13 @@ sf.org.subscription.hosts:
       * Data resolution: 10 seconds
   metric_type: gauge
   title: sf.org.subscription.hosts
+ 
+sf.org.subscription.function:
+  brief: Number of functions.
+  description: |
+    Number of functions.
+    
+    * Data resolution: 2 minutes
+  metric_type: gauge
+  title: sf.org.subscription.function
+  

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1677,25 +1677,25 @@ sf.org.log.numContentBytesReceivedByToken:
 sf.org.subscription.containers:
   brief: Number of containers.
   description: |
-    Number of containers.
+    Number of containers included in the subscription.
     
     * Data resolution: 10 seconds
   metric_type: gauge
   title: sf.org.subscription.containers
 
 sf.org.subscription.customMetrics:
-  brief: Number of custom metric time series.
+  brief: Number of custom metric time series (MTS).
   description: |
-    Number of custom metric time series.
+    Number of custom metric time series (MTS) included in the subscription.
     
     * Data resolution: 10 seconds
   metric_type: gauge
   title: sf.org.subscription.customMetrics
 
 sf.org.subscription.highResolutionMetrics:
-  brief: Number of high resolution metric time series.
+  brief: Number of high resolution metric time series (MTS).
   description: |
-    Number of high resolution metric time series.
+    Number of high resolution metric time series (MTS) included in the subscription.
       
     * Data resolution: 10 seconds
   metric_type: gauge
@@ -1704,7 +1704,7 @@ sf.org.subscription.highResolutionMetrics:
 sf.org.subscription.hosts:
   brief: Number of hosts.
   description: |
-    Number of hosts.
+    Number of hosts included in the subscription.
     
       * Data resolution: 10 seconds
   metric_type: gauge

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1677,7 +1677,7 @@ sf.org.log.numContentBytesReceivedByToken:
 sf.org.subscription.containers:
   brief: Number of containers.
   description: |
-    Number of containers.
+    Number of containers that are being monitored.
     
     * Data resolution: 10 seconds
   metric_type: gauge
@@ -1686,7 +1686,7 @@ sf.org.subscription.containers:
 sf.org.subscription.customMetrics:
   brief: Number of custom metric time series.
   description: |
-    Number of custom metric time series.
+    Number of custom metric time series that are received. 
     
     * Data resolution: 10 seconds
   metric_type: gauge
@@ -1695,7 +1695,7 @@ sf.org.subscription.customMetrics:
 sf.org.subscription.highResolutionMetrics:
   brief: Number of high resolution metric time series.
   description: |
-    Number of high resolution metric time series.
+    Number of high resolution metric time series that are received.
       
     * Data resolution: 10 seconds
   metric_type: gauge
@@ -1704,7 +1704,7 @@ sf.org.subscription.highResolutionMetrics:
 sf.org.subscription.hosts:
   brief: Number of hosts.
   description: |
-    Number of hosts.
+    Number of hosts that are being monitored. 
     
       * Data resolution: 10 seconds
   metric_type: gauge
@@ -1713,7 +1713,7 @@ sf.org.subscription.hosts:
 sf.org.subscription.function:
   brief: Number of functions.
   description: |
-    Number of functions.
+    Number of functions that are being monitored.
     
     * Data resolution: 2 minutes
   metric_type: gauge

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1677,7 +1677,7 @@ sf.org.log.numContentBytesReceivedByToken:
 sf.org.subscription.containers:
   brief: Number of containers.
   description: |
-    Number of containers that are being monitored.
+    Number of containers.
     
     * Data resolution: 10 seconds
   metric_type: gauge
@@ -1686,7 +1686,7 @@ sf.org.subscription.containers:
 sf.org.subscription.customMetrics:
   brief: Number of custom metric time series.
   description: |
-    Number of custom metric time series that are received. 
+    Number of custom metric time series.
     
     * Data resolution: 10 seconds
   metric_type: gauge
@@ -1695,7 +1695,7 @@ sf.org.subscription.customMetrics:
 sf.org.subscription.highResolutionMetrics:
   brief: Number of high resolution metric time series.
   description: |
-    Number of high resolution metric time series that are received.
+    Number of high resolution metric time series.
       
     * Data resolution: 10 seconds
   metric_type: gauge
@@ -1704,7 +1704,7 @@ sf.org.subscription.highResolutionMetrics:
 sf.org.subscription.hosts:
   brief: Number of hosts.
   description: |
-    Number of hosts that are being monitored. 
+    Number of hosts.
     
       * Data resolution: 10 seconds
   metric_type: gauge
@@ -1713,7 +1713,7 @@ sf.org.subscription.hosts:
 sf.org.subscription.function:
   brief: Number of functions.
   description: |
-    Number of functions that are being monitored.
+    Number of serverless functions included in the subscription.
     
     * Data resolution: 2 minutes
   metric_type: gauge

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1291,9 +1291,10 @@ sf.org.numPropertyLimitedMetricTimeSeriesCreateCallsByToken:
   title: sf.org.numPropertyLimitedMetricTimeSeriesCreateCallsByToken
 
 sf.org.numResourceMetrics:
-  brief: Number of host-based resource metric time series.
+  brief: Number of resource metric time series (MTS).
   description: |
-    Number of host-based resource metric time series.
+    Number of resource metric time series (MTS) received from host and container 
+    categories. 
     
     * Dimension(s): `orgId`, `resourceType`
     * Data resolution: 10 minutes


### PR DESCRIPTION
Expanded from DOCS-2113. Add two metrics to metrics.yaml:

- sf.org.subscription.function
- sf.org.numResourceMetrics