### PR TITLE
Update metrics.yaml sf.org.num.awsServiceAuthErrorCount 

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -370,6 +370,16 @@ sf.org.num.alertmuting:
   metric_type: gauge
   title: sf.org.num.alertmuting
 
+sf.org.num.awsServiceAuthErrorCount
+brief: Authentication errors thrown by AWS services
+  description: |
+    Total number authentication errors thrown by AWS services.
+
+        * Dimension(s):  `integrationId`,`orgId`,`namespace` (AWS Cloudwatch namespace),`clientInterface` (AWS SDK Interface),`method` (AWS SDK method)
+        * Data resolution: 1 second
+  metric_type: gauge
+  title: sf.org.num.awsServiceAuthErrorCount
+
 sf.org.num.awsServiceCallCount:
   brief: Number of calls made to the Amazon API
   description: |


### PR DESCRIPTION
updated the sf.org.num.awsServiceAuthErrorCount metric per https://signalfuse.atlassian.net/browse/DOCS-4443