### PR TITLE
[DOCS-4606] add sf.org.numDatapointsDroppedInvalidByToken

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -1187,6 +1187,15 @@ sf.org.numDatapointsDroppedInvalid:
   metric_type: counter
   title: sf.org.numDatapointsDroppedInvalid
 
+  sf.org.numDatapointsDroppedInvalidByToken:
+    brief: Number of data points dropped because they didn't follow documented guidelines for data points.
+    description: |
+      Number of data points for a specific access token that are dropped because they didn't follow documented guidelines for data points. For example, the metric name was too long, the metric name included unsupported characters, or the data point contained no values.
+          * Dimension(s):  `orgId`, `tokenId`
+          * Data resolution: 10 seconds
+    metric_type: counter
+    title: sf.org.numDatapointsDroppedInvalidByToken
+
 sf.org.numDatapointsDroppedInTimeout:
   brief: Number of data points Observability Cloud didn't attempt to create because your account was throttled or limited in the previous few seconds.
   description: |


### PR DESCRIPTION
Add missing metric: sf.org.numDatapointsDroppedInvalidByToken in response to doc feedback: [DOCGUILD-18862: Doc feedback for https://docs.splunk.com/Observability/admin/org-metrics.html#feedbackModalIN PROGRESS](https://splunk.atlassian.net/browse/DOCGUILD-18862)