### PR TITLE
Fix link formatting (#1032)

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -700,7 +700,7 @@ sf.org.num.awsServiceAuthErrorCount:
   description: |
     Total number authentication errors thrown by AWS services.
   
-      * Dimension(s):  `integrationId`,`orgId`,`namespace` (AWS Cloudwatch namespace),`clientInterface` (AWS SDK Interface),`method` (AWS SDK method)
+      * Dimension(s):  `integrationId`, `orgId`, `namespace` (AWS Cloudwatch namespace),`clientInterface` (AWS SDK Interface), `method` (AWS SDK method)
       * Data resolution: 1 second
   metric_type: gauge
   title: sf.org.num.awsServiceAuthErrorCount
@@ -1323,17 +1323,16 @@ sf.org.numComputationsStartedByToken:
 sf.org.numComputationsThrottled:
   brief: Rate at which SignalFlow jobs are being throttled
   description: |
-    The number of SignalFlow computations, which mostly consist of chart views and detectors, throttled because you reach the maximum number of SignalFlow jobs you can run for your organization. To learn more about this limit, see (Maximum number of SignalFlow jobs per organization)[https://docs.splunk.com/observability/admin/references/system-limits/sys-limits-infra.html#maximum-number-of-signalflow-jobs-per-organization].
+    The number of SignalFlow computations, which mostly consist of chart views and detectors, throttled because you reach the maximum number of SignalFlow jobs you can run for your organization. To learn more about this limit, see [Maximum number of SignalFlow jobs per organization](https://docs.splunk.com/observability/admin/references/system-limits/sys-limits-infra.html#maximum-number-of-signalflow-jobs-per-organization).
 
       * Dimension(s):  `orgId`
       * Data resolution: 10 seconds
   metric_type: counter
   title: sf.org.numComputationsThrottled
-
 sf.org.numComputationsThrottledByToken:
   brief: Rate at which SignalFlow jobs are being throttled
   description: |
-    One value per token. The number of computations, which mostly consist of chart views and detectors, throttled because you reach the maximum number of SignalFlow jobs you can run for your organization. To learn more about this limit, see (Maximum number of SignalFlow jobs per organization)[https://docs.splunk.com/observability/admin/references/system-limits/sys-limits-infra.html#maximum-number-of-signalflow-jobs-per-organization].
+    One value per token. The number of computations, which mostly consist of chart views and detectors, throttled because you reach the maximum number of SignalFlow jobs you can run for your organization. To learn more about this limit, see [Maximum number of SignalFlow jobs per organization](https://docs.splunk.com/observability/admin/references/system-limits/sys-limits-infra.html#maximum-number-of-signalflow-jobs-per-organization).
 
       * Dimension(s):  `orgId`, `tokenId`
       * Data resolution: 10 seconds


### PR DESCRIPTION
* DOCS-3971 Switch descriptions for metrics (#966)

* DOCS-3971: Switch descriptions for metrics

Doc feedback given in this JIRA ticket: https://signalfuse.atlassian.net/browse/DOCS-3971

* Added period

* updated data resolution fields for swapped metrics

* Add entry for numLimitedMetricTimeSeriesCreateCallsByCategoryTypeByToken (#967)

* Add entry for numLimitedMetricTimeSeriesCreateCallsByCategoryTypeByToken

* Use MD not RST syntax

* DOCS-2113: Document subscription metrics (#968)

* Add host-based limit metrics to metrics.yaml

* Update metrics.yaml

* Revert "DOCS-2113: Document subscription metrics (#968)" (#969)

This reverts commit bee12adf906483f35795288da69ccd09c483425b.

* Update metrics.yaml (#970)

* Jmalin docs4360 no mts definition (#972)

* DOC-4360: Add MTS definitions

Add definitions of active and inactive MTS.

* DOCS-4360: Edit and cleanup

* DOCS-1552: Update documentation of IMM Metrics (#971)

* Update metrics.yaml

* Add two metrics to metrics.yaml

* Update sf.org.numResourceMetrics

* Update descriptions of new metrics

* Update sf.org.subscription.function description

* Add subscription details to new metrics

* Update from Joe suggestions

* Changes to metrics.yaml

* Update docs for v5.23.0 (#974)

SignalFx Smart Agent release v5.23.0 contained multiple documentation changes. This commit updates integration docs to match changes.

* Mfoulds doc4443 (#976)

* added space before brief

* Update metrics.yaml (#975)

* added spaces to line 374 to fix build error(?)

* DOCS-4504: Fix YAML file (#978)

Fix formatting problems in signalfx-org-metrics/metrics.yaml

* Update metrics.yaml (#980)

* fixed typos (#982)

* merge jmalin-docs-4360-no-MTS-definition changes from master to release (#973) (#985)

* DOCS-3971 Switch descriptions for metrics (#966)

* DOCS-3971: Switch descriptions for metrics

Doc feedback given in this JIRA ticket: https://signalfuse.atlassian.net/browse/DOCS-3971

* Added period

* updated data resolution fields for swapped metrics

* Add entry for numLimitedMetricTimeSeriesCreateCallsByCategoryTypeByToken (#967)

* Add entry for numLimitedMetricTimeSeriesCreateCallsByCategoryTypeByToken

* Use MD not RST syntax

* DOCS-2113: Document subscription metrics (#968)

* Add host-based limit metrics to metrics.yaml

* Update metrics.yaml

* Revert "DOCS-2113: Document subscription metrics (#968)" (#969)

This reverts commit bee12adf906483f35795288da69ccd09c483425b.

* Update metrics.yaml (#970)

* Jmalin docs4360 no mts definition (#972)

* DOC-4360: Add MTS definitions

Add definitions of active and inactive MTS.

* DOCS-4360: Edit and cleanup









* [DOCS-2512] Org metrics redux (#991)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* DRAFT [DOCS-4678] - Org metrics batch A  (#992)

* [DOCS-4678] - Org metrics batch A

See jira.

* More updates, WIP

* Final updates to Batch A

* update docs with splunk.com links (#996)

* update docs with splunk.com links

* lowercase observability

* remove CircleCI, use github actions (#995)

* Code review changes from #995 (#997)

* code review

* Update .github/workflows/test.yml

* rename to build-and-test

* add sf.org.numDatapointsDroppedInvalidByToken metric (#983)

* add sf.org.numDatapointsDroppedInvalidByToken metric

* ByToken metric updates

* Revert "add sf.org.numDatapointsDroppedInvalidByToken metric (#983)" (#998)

This reverts commit 8330ce38f9ce0b4c39b22f6765ebdbf5c12bf72f.

* DOCS-4464: add RUM org metrics  (#993)

* RUM metrics draft

* additions

* fixes

* chages

* fix endpoint

* reason decripion

* revisions

* small fix

* Remove typo

* remove blank spaces

* revisions

* add sf.org.numDatapointsDroppedInvalidByToken (#999)

* Revert "add sf.org.numDatapointsDroppedInvalidByToken (#999)" (#1003)

This reverts commit 9102b6dc421eb09ebc373d2f64c33599f72e802d.

* DOC-4606 feedback missing metric (#1004)

* add sf.org.numDatapointsDroppedInvalidByToken

* add metric with proper indentation

* add metric sf.org.log.numMessagesReceivedByToken (#1001)

* Removing old metrics (#1006)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Org metrics update (#1008)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* [DOCS-4776]: AWS org metrics (#994)

* DOCS-4776 

New org metrics for AWS

* WIP, added info

* Final definitions

* Org Metrics updates. (#1012)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

---------



* Merging changes in master (#1014)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

* DOCS-5114-fix (#1013)

---------



* [DOCS-4679]: Adding more Org metrics (#1009)

* [DOCS-4679]: Adding more Org metrics

* Added bad calls

* Final metrics from batch

* Add new Azure metrics and deprecate old ones (#1015)

* add sf.org.log.numLogsDroppedIndexThrottle (#1016)

* OD4680 More Org metrics (#1022)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

* DOCS-5114-fix (#1013)

* Update metrics - 4680 - batch C.yaml (#1021)

* Update metrics - 4680 - batch C.yaml

* Update metrics.yaml

WIP

* Update metrics.yaml

---------



* Org metrics update - batch D (#1024)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

* DOCS-5114-fix (#1013)

* Update metrics - 4680 - batch C.yaml (#1021)

* Update metrics - 4680 - batch C.yaml

* Update metrics.yaml

WIP

* Update metrics.yaml

* Update metrics - batch D.yaml (#1023)

* Update metrics - batch D.yaml

* Update metrics.yaml

* Final metrics from batch

---------



* Removing Reserved note in Org metrics (#1026)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

* DOCS-5114-fix (#1013)

* Update metrics - 4680 - batch C.yaml (#1021)

* Update metrics - 4680 - batch C.yaml

* Update metrics.yaml

WIP

* Update metrics.yaml

* Update metrics - batch D.yaml (#1023)

* Update metrics - batch D.yaml

* Update metrics.yaml

* Final metrics from batch

* OD5392-removed-reserved (#1025)

Removed "reserved" note.

---------



* Update metrics.yaml (#1027)

* OD3972-dpm-faqs (#1028)

See jira for more details.

* update java lib (#1018)

* Add missing org metrics per feedback (#1029)

* Formatting

* Change to fix build failure

* Clarify SignalFlow jobs

* Eng review

* Merge changes in main to release (#1002) (#1031)

* DOCS-3971 Switch descriptions for metrics (#966)

* DOCS-3971: Switch descriptions for metrics

Doc feedback given in this JIRA ticket: https://signalfuse.atlassian.net/browse/DOCS-3971

* Added period

* updated data resolution fields for swapped metrics

* Add entry for numLimitedMetricTimeSeriesCreateCallsByCategoryTypeByToken (#967)

* Add entry for numLimitedMetricTimeSeriesCreateCallsByCategoryTypeByToken

* Use MD not RST syntax

* DOCS-2113: Document subscription metrics (#968)

* Add host-based limit metrics to metrics.yaml

* Update metrics.yaml

* Revert "DOCS-2113: Document subscription metrics (#968)" (#969)

This reverts commit bee12adf906483f35795288da69ccd09c483425b.

* Update metrics.yaml (#970)

* Jmalin docs4360 no mts definition (#972)

* DOC-4360: Add MTS definitions

Add definitions of active and inactive MTS.

* DOCS-4360: Edit and cleanup

* DOCS-1552: Update documentation of IMM Metrics (#971)

* Update metrics.yaml

* Add two metrics to metrics.yaml

* Update sf.org.numResourceMetrics

* Update descriptions of new metrics

* Update sf.org.subscription.function description

* Add subscription details to new metrics

* Update from Joe suggestions

* Changes to metrics.yaml

* Update docs for v5.23.0 (#974)

SignalFx Smart Agent release v5.23.0 contained multiple documentation changes. This commit updates integration docs to match changes.

* Mfoulds doc4443 (#976)

* added space before brief

* Update metrics.yaml (#975)

* added spaces to line 374 to fix build error(?)

* DOCS-4504: Fix YAML file (#978)

Fix formatting problems in signalfx-org-metrics/metrics.yaml

* Update metrics.yaml (#980)

* fixed typos (#982)

* merge jmalin-docs-4360-no-MTS-definition changes from master to release (#973) (#985)

* DOCS-3971 Switch descriptions for metrics (#966)

* DOCS-3971: Switch descriptions for metrics

Doc feedback given in this JIRA ticket: https://signalfuse.atlassian.net/browse/DOCS-3971

* Added period

* updated data resolution fields for swapped metrics

* Add entry for numLimitedMetricTimeSeriesCreateCallsByCategoryTypeByToken (#967)

* Add entry for numLimitedMetricTimeSeriesCreateCallsByCategoryTypeByToken

* Use MD not RST syntax

* DOCS-2113: Document subscription metrics (#968)

* Add host-based limit metrics to metrics.yaml

* Update metrics.yaml

* Revert "DOCS-2113: Document subscription metrics (#968)" (#969)

This reverts commit bee12adf906483f35795288da69ccd09c483425b.

* Update metrics.yaml (#970)

* Jmalin docs4360 no mts definition (#972)

* DOC-4360: Add MTS definitions

Add definitions of active and inactive MTS.

* DOCS-4360: Edit and cleanup









* [DOCS-2512] Org metrics redux (#991)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* DRAFT [DOCS-4678] - Org metrics batch A  (#992)

* [DOCS-4678] - Org metrics batch A

See jira.

* More updates, WIP

* Final updates to Batch A

* update docs with splunk.com links (#996)

* update docs with splunk.com links

* lowercase observability

* remove CircleCI, use github actions (#995)

* Code review changes from #995 (#997)

* code review

* Update .github/workflows/test.yml

* rename to build-and-test

* add sf.org.numDatapointsDroppedInvalidByToken metric (#983)

* add sf.org.numDatapointsDroppedInvalidByToken metric

* ByToken metric updates

* Revert "add sf.org.numDatapointsDroppedInvalidByToken metric (#983)" (#998)

This reverts commit 8330ce38f9ce0b4c39b22f6765ebdbf5c12bf72f.

* DOCS-4464: add RUM org metrics  (#993)

* RUM metrics draft

* additions

* fixes

* chages

* fix endpoint

* reason decripion

* revisions

* small fix

* Remove typo

* remove blank spaces

* revisions

* add sf.org.numDatapointsDroppedInvalidByToken (#999)

* Revert "add sf.org.numDatapointsDroppedInvalidByToken (#999)" (#1003)

This reverts commit 9102b6dc421eb09ebc373d2f64c33599f72e802d.

* DOC-4606 feedback missing metric (#1004)

* add sf.org.numDatapointsDroppedInvalidByToken

* add metric with proper indentation

* add metric sf.org.log.numMessagesReceivedByToken (#1001)

* Removing old metrics (#1006)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Org metrics update (#1008)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* [DOCS-4776]: AWS org metrics (#994)

* DOCS-4776 

New org metrics for AWS

* WIP, added info

* Final definitions

* Org Metrics updates. (#1012)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

---------



* Merging changes in master (#1014)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

* DOCS-5114-fix (#1013)

---------



* [DOCS-4679]: Adding more Org metrics (#1009)

* [DOCS-4679]: Adding more Org metrics

* Added bad calls

* Final metrics from batch

* Add new Azure metrics and deprecate old ones (#1015)

* add sf.org.log.numLogsDroppedIndexThrottle (#1016)

* OD4680 More Org metrics (#1022)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

* DOCS-5114-fix (#1013)

* Update metrics - 4680 - batch C.yaml (#1021)

* Update metrics - 4680 - batch C.yaml

* Update metrics.yaml

WIP

* Update metrics.yaml

---------



* Org metrics update - batch D (#1024)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

* DOCS-5114-fix (#1013)

* Update metrics - 4680 - batch C.yaml (#1021)

* Update metrics - 4680 - batch C.yaml

* Update metrics.yaml

WIP

* Update metrics.yaml

* Update metrics - batch D.yaml (#1023)

* Update metrics - batch D.yaml

* Update metrics.yaml

* Final metrics from batch

---------



* Removing Reserved note in Org metrics (#1026)

* DOCS-2512: Org metrics updates (#989)

* DOCS-2512: Org metrics updates

* Added minimum to def

* Added two more metrics

* sf.org.datapointsTotalCountByToken

* Typo

* sf.org.grossDpmContentBytesReceived

* Arranged alphabetically

* sf.org.log.grossContentBytesReceived WIP

* Finalizing batch, reordering lohs

* Updates

* Revert "DOCS-2512: Org metrics updates (#989)" (#990)

This reverts commit 239a202ef7a9a33a5d0c5df7466f785bdaea3f5e.

* Removed old metrics (#1005)

See https://signalfuse.atlassian.net/browse/DOCS-5040.

* Updating Org metrics (#1007)

* Putting updated metrics back

See DOCS-5040.

* Removed dimension

* Add new GCP metrics and deprecate old ones (#1010)

sf.org.num.gcpStackdriverClientCallCount* are being deprecated and will be removed. Those are being replaced with sf.org.num.gcpServiceClientCallCount* metrics that present more accurate data.

* DOCS-5114-removing-metrics (#1011)

* DOCS-5114-fix (#1013)

* Update metrics - 4680 - batch C.yaml (#1021)

* Update metrics - 4680 - batch C.yaml

* Update metrics.yaml

WIP

* Update metrics.yaml

* Update metrics - batch D.yaml (#1023)

* Update metrics - batch D.yaml

* Update metrics.yaml

* Final metrics from batch

* OD5392-removed-reserved (#1025)

Removed "reserved" note.

---------



* Update metrics.yaml (#1027)

* OD3972-dpm-faqs (#1028)

See jira for more details.

* update java lib (#1018)

* Add missing org metrics per feedback (#1029)

* Formatting

* Change to fix build failure

* Clarify SignalFlow jobs

* Eng review

---------














* Fix link formatting

---------