### PR TITLE
[6316] New histogram org metrics

### DIFF
--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -2274,7 +2274,8 @@ sf.org.rum.grossReplayContentBytesReceived:
 sf.org.numHistogramCustomMetrics:
   brief: The number of custom histogram metrics. 
   description: |
-    The number of custom histogram metrics monitored in Infrastructure Monitoring.
+    The number of custom histogram metrics monitored in Splunk Observability Cloud. For billing purposes, this is the raw number of custom histogram metrics
+    and isn't multiplied.
 
     * Dimension(s): `orgId`
     * Data resolution: 10 minutes
@@ -2284,9 +2285,10 @@ sf.org.numHistogramCustomMetrics:
 sf.org.numHistogramCustomMetricsByToken:
   brief: The number of custom histogram metrics by token.
   description: |
-    The number of custom histogram metrics monitored in Infrastructure Monitoring.
+    The number of custom histogram metrics monitred in Splunk Observability Cloud for a specific token. For billing purposes, this is the raw number of 
+    custom histogram metrics and isn't multiplied.
 
-    * Dimension(s): `orgId`
+    * Dimension(s): `orgId`, `tokenId`
     * Data resolution: 10 minutes.
   metric_type: counter
   title: sf.org.numHistogramCustomMetricsByToken

--- a/signalfx-org-metrics/metrics.yaml
+++ b/signalfx-org-metrics/metrics.yaml
@@ -2270,3 +2270,23 @@ sf.org.rum.grossReplayContentBytesReceived:
      * Data resolution: 10 seconds
   metric_type: counter
   title: sf.org.rum.grossReplayContentBytesReceived
+
+sf.org.numHistogramCustomMetrics:
+  brief: The number of custom histogram metrics. 
+  description: |
+    The number of custom histogram metrics monitored in Infrastructure Monitoring.
+
+    * Dimension(s): `orgId`
+    * Data resolution: 10 minutes
+  metric_type: counter
+  title: sf.org.numHistogramCustomMetrics
+
+sf.org.numHistogramCustomMetricsByToken:
+  brief: The number of custom histogram metrics by token.
+  description: |
+    The number of custom histogram metrics monitored in Infrastructure Monitoring.
+
+    * Dimension(s): `orgId`
+    * Data resolution: 10 minutes.
+  metric_type: counter
+  title: sf.org.numHistogramCustomMetricsByToken


### PR DESCRIPTION
Ticket: https://splunk.atlassian.net/browse/O11YDOCS-6316

Adds two new histogram org metrics to the table: 

* `numHistogramCustomMetrics`
* `numHistogramCustomMetricsByToken`