### PR TITLE
using shutil.move instead of replace

### DIFF
--- a/build
+++ b/build
@@ -167,7 +167,7 @@ def do_build():
     symlink_images(tmp_dir)
 
     shutil.rmtree(OUT_DIR, ignore_errors=True)
-    tmp_dir.replace(OUT_DIR)
+    shutil.move(str(tmp_dir), OUT_DIR)
 
 
 do_build()


### PR DESCRIPTION
replace was throwing errors in CI. I asked AI and the recommendation is to use `move` which works within CI environments. The specific error is:

```
10:29:01 Traceback (most recent call last):
10:29:01   File "/opt/jenkins/workspace/integrations-docs-lab-update/./build", line 173, in <module>
10:29:01     do_build()
10:29:01   File "/opt/jenkins/workspace/integrations-docs-lab-update/./build", line 170, in do_build
10:29:01     tmp_dir.replace(OUT_DIR)
10:29:01   File "/usr/lib/python3.11/pathlib.py", line 1188, in replace
10:29:01     os.replace(self, target)
10:29:01 OSError: [Errno 18] Cross-device link: '/tmp/tmp8azgw2si' -> '/opt/jenkins/workspace/integrations-docs-lab-update/dist'
```

This change still works locally so there should be no issue with using it!