### PR TITLE
SYN-5828 - adding Metric Finder lab/rc deployment information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,19 @@ The O11y frontend uses the `integrations-docs.js` output file from the `./build`
 
 You release to Lab/RC with the job [integrations-doc-lab-release](https://ci-qe.corp.signalfx.com/job/integrations-doc-lab-release/) as a manual trigger in Jenkins. It clones this repo and runs the `./build` script to build the latest version of `integrations-docs.js` and promote it to s3. As of now, there is no promotion to prod as the old trigger was lost and the new trigger will be added in the future.
 
+### Notes
+
+This process assumes that all changes are going into `main` first. The `main` branch is already the source of truth for the [organizational metrics docs](https://help.splunk.com/en/splunk-observability-cloud/administer/view-organization-metrics#view-organization-metrics-for-splunk-observability-cloud).
+
+
+**Do not create PRs to `release` branch.** All changes are reviewed first in `main` by maintainers.
+
+For additional information on ownership, process and recommendations, read [here](https://splunk.atlassian.net/wiki/spaces/PROD/pages/1078211401643/Maintaining+signalfx-org-metrics+metrics.yaml).
+
+
 ### Steps
 
-1. When you want to deploy a new version, create a PR to the `release` branch. The `release` branch is what is used in the Jenkins pipeline to build and promote the latest version of `integrations-docs.js` to s3.
+1. When you want to deploy a new version, create a PR from `main`to the `release` branch. The `release` branch is what is used in the Jenkins pipeline to build and promote the latest version of `integrations-docs.js` to s3.
 2. Merge the PR to the `release` branch.
 3. Go to the [release Jenkins job](https://ci-qe.corp.signalfx.com/job/integrations-doc-lab-release/) and run it by clicking "Build Now". The job will first copy the existing file to a temporary bucket in order to have a copy of the current version in case there is need to rollback.
 4. The job will then build the new version of `integrations-docs.js` and promote it to s3.


### PR DESCRIPTION
Adds documentation for how to deploy the `integrations-docs.js` file so that the O11y Frontend has the latest details in the Metrics Finder UI. Result looks like: 
<img width="857" height="534" alt="Screenshot 2025-09-23 at 7 26 21 AM" src="https://github.com/user-attachments/assets/7867272a-51e1-4bdc-8367-ed21875ddd83" />
