### PR TITLE
VULN-53954 and VULN-53956: Added  to enforce a read-only root filesystem and configured the containers to mount to use a temporary place for writing files with emptyDir volume (which acts as a tmpfs) to /tmp.

### DIFF
--- a/kubernetes/cadvisor-signalfx.yaml
+++ b/kubernetes/cadvisor-signalfx.yaml
@@ -15,6 +15,11 @@ spec:
       containers:
       - name: "cadvisor-signalfx"
         image: "quay.io/signalfx/cadvisor-integration:latest"
+        # Security context added to prevent writing to the root filesystem
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
         env:
         - name: SFX_SCRAPPER_API_TOKEN
           value: <API TOKEN>
@@ -22,3 +27,10 @@ spec:
           value: <CLUSTER NAME>
         - name: SFX_SCRAPPER_SEND_RATE
           value: 5s
+        # Mount a temporary volume for applications that need to write to /tmp
+        volumeMounts:
+        - name: tmp-storage
+          mountPath: /tmp
+      volumes:
+      - name: tmp-storage
+        emptyDir: {}

--- a/kubernetes/cadvisor-signalfx.yaml
+++ b/kubernetes/cadvisor-signalfx.yaml
@@ -15,11 +15,11 @@ spec:
       containers:
       - name: "cadvisor-signalfx"
         image: "quay.io/signalfx/cadvisor-integration:latest"
-        # Security context added to prevent writing to the root filesystem
         securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true  
+          runAsNonRoot: true            
+          runAsUser: 1001               
+          allowPrivilegeEscalation: false 
         env:
         - name: SFX_SCRAPPER_API_TOKEN
           value: <API TOKEN>
@@ -27,7 +27,6 @@ spec:
           value: <CLUSTER NAME>
         - name: SFX_SCRAPPER_SEND_RATE
           value: 5s
-        # Mount a temporary volume for applications that need to write to /tmp
         volumeMounts:
         - name: tmp-storage
           mountPath: /tmp


### PR DESCRIPTION
Key Changes Made:

* `securityContext.readOnlyRootFilesystem: true:` -  This directly addresses the vulnerability report. It ensures that the container cannot modify any files in its root filesystem. If a process attempts to write to a directory that isn't explicitly mounted as writable, the operation will fail.

* `volumeMounts` and v`olumes`: - I added an `emptyDir` volume named `tmp-storage`. I mounted this volume at `/tmp`. This provides the container with a writable space for temporary files (using the node's storage or RAM) without compromising the security of the entire container image.

Additional Hardening (Recommended):
* `runAsNonRoot: true:` -  Ensures the container does not run with root privileges.
* `allowPrivilegeEscalation: false:` -  Prevents a process from gaining more privileges than its parent process.

Added default user to prevent the container running as root: ` runAsUser: 1001`
